### PR TITLE
fix: Updated Jupyter Notebook pods with different service account with no permissions

### DIFF
--- a/deploy/kubernetes/jupyterhub-configs.yaml
+++ b/deploy/kubernetes/jupyterhub-configs.yaml
@@ -16,7 +16,7 @@ data:
     c.KubeSpawner.image_spec='labshare/polyglot-notebook:${NOTEBOOK_VERSION}'
     c.KubeSpawner.cmd = 'start-singleuser.sh'
     c.KubeSpawner.args = ['--allow-root']
-    c.KubeSpawner.service_account='jupyterhub-sa'
+    c.KubeSpawner.service_account='jupyteruser-sa'
 
     c.JupyterHub.allow_named_servers=True
     c.JupyterHub.ip='0.0.0.0'

--- a/deploy/kubernetes/jupyterhub-predefined.yaml
+++ b/deploy/kubernetes/jupyterhub-predefined.yaml
@@ -23,3 +23,8 @@ roleRef:
   kind: Role
   name: jupyterhub-role
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jupyteruser-sa

--- a/run/jupyterhub-sample.yaml
+++ b/run/jupyterhub-sample.yaml
@@ -3,6 +3,11 @@ kind: ServiceAccount
 metadata:
   name: jupyterhub-sa
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jupyteruser-sa
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -63,7 +68,7 @@ data:
     c.KubeSpawner.uid = 1000 #uid 1000 corresponds to jovyan, uid 0 to root
     c.KubeSpawner.cmd = ['jupyter-labhub']
     c.KubeSpawner.working_dir = '/opt/notebooks'
-    c.KubeSpawner.service_account='jupyterhub-sa'
+    c.KubeSpawner.service_account='jupyteruser-sa'
 
     c.JupyterHub.authenticator_class='dummyauthenticator.DummyAuthenticator'
     c.JupyterHub.allow_named_servers=True


### PR DESCRIPTION
- New serviceaccount: `jupyteruser-sa`
- No roles currently bound with this serviceaccount --> no permissions are given
- In the future we should only add resources that are required by pods, i.e. scheduling