### PR TITLE
Updates to Rook/Ceph configuration

### DIFF
--- a/deploy/kubernetes/infrastructure/rook-ceph.yaml
+++ b/deploy/kubernetes/infrastructure/rook-ceph.yaml
@@ -650,7 +650,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:master
+        image: rook/ceph:v1.0.4
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook
@@ -800,12 +800,12 @@ metadata:
 spec:
   metadataPool:
     replicated:
-      size: 2
+      size: 3
   dataPools:
     - replicated:
-        size: 2
+        size: 3
   metadataServer:
-    activeCount: 1
+    activeCount: 3
     activeStandby: true
 ---
 #################################################################################################################
@@ -820,3 +820,26 @@ spec:
   failureDomain: host
   replicated:
     size: 3
+---
+#################################################################################################################
+# Enable Ceph Dashboard
+#################################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: rook-ceph-mgr-dashboard-external-https
+  namespace: rook-ceph
+  labels:
+    app: rook-ceph-mgr
+    rook_cluster: rook-ceph
+spec:
+  ports:
+  - name: dashboard
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: rook-ceph-mgr
+    rook_cluster: rook-ceph
+  sessionAffinity: None
+  type: LoadBalancer


### PR DESCRIPTION
fix: Using version number tag of rook container instead of 'master' tag
feat: Made Ceph dashboard service available through the load balancer
Using more replicated data and metadata pools