### PR TITLE
Move per-user storage mount and the Jupyter working dir to the system home folder

### DIFF
--- a/deploy/kubernetes/jupyterhub-configs.yaml
+++ b/deploy/kubernetes/jupyterhub-configs.yaml
@@ -17,7 +17,7 @@ data:
     c.KubeSpawner.default_url = '/lab'
     c.KubeSpawner.uid = 1000 #uid 1000 corresponds to jovyan, uid 0 to root
     c.KubeSpawner.cmd = ['jupyter-labhub']
-    c.KubeSpawner.working_dir = '/opt/notebooks'
+    c.KubeSpawner.working_dir = '/home/jovyan'
     c.KubeSpawner.service_account='jupyteruser-sa'
 
     # Per-user storage configuration
@@ -46,7 +46,7 @@ data:
     # Where to mount volumes
     c.KubeSpawner.volume_mounts = [
       {
-        'mountPath': '/opt/notebooks',
+        'mountPath': '/home/jovyan',
         'name': 'volume-{username}'
       },
       {


### PR DESCRIPTION
This is less confusing situation for our users, especially if they are using the terminal. `cd` command always moves user to `/home/jovyan` folder and we want that to also be the Jupyter working dir.
Access to the shared filesystem is also include through symlink (look at the previous commits): `/home/jovyan/shared` → `/opt/shared`