### PR TITLE
fix: Move persistent volume mount to /home/jovyan/work/

### DIFF
--- a/deploy/kubernetes/jupyterhub-configs.yaml
+++ b/deploy/kubernetes/jupyterhub-configs.yaml
@@ -17,7 +17,7 @@ data:
     c.KubeSpawner.default_url = '/lab'
     c.KubeSpawner.uid = 1000 #uid 1000 corresponds to jovyan, uid 0 to root
     c.KubeSpawner.cmd = ['jupyter-labhub']
-    c.KubeSpawner.working_dir = '/home/jovyan/work'
+    c.KubeSpawner.working_dir = '/home/jovyan'
     c.KubeSpawner.service_account='jupyteruser-sa'
 
     # Per-user storage configuration


### PR DESCRIPTION
Mounting persistent volume directly to `/home/jovyan` substitutes all existing files in that folder which include kernels and config.
Now the home folder have the following structure:
- `work`: persistent user storage
- `shared`: persistent shared storage (symlink)
- hidden config files (i.e. `.bashrc`)
- everything else is in that directory is temporary and does not survive the restart