### PR TITLE
fix: Form string correctly

### DIFF
--- a/deploy/docker/jupyterhub/modularspawner/modularspawner/spawner.py
+++ b/deploy/docker/jupyterhub/modularspawner/modularspawner/spawner.py
@@ -46,7 +46,7 @@ class ModularSpawner(KubeSpawner):
             #if image does not exist, switch to the maximal image with all stacks included
             self.log.debug("Requested tag %s is not in registry, using default image", tag)
             options = [True] * len(self.stacks)
-            tag = subprocess.run(('railyard hash ' + '-b ' + self.base + ' ' + ' '.join([f'-a {item}' for stack,included in zip(self.stacks,options) for item in stack if included])).split(' '), capture_output=True).stdout.decode("utf-8").rstrip()
+            tag = subprocess.run(('railyard hash ' + '-b ' + self.base + ''.join([f' -a {item}' for stack,included in zip(self.stacks,options) for item in stack if included])).split(' '), capture_output=True).stdout.decode("utf-8").rstrip()
         
         # Get full image tag
         image = 'labshare/polyglot-notebook:' + tag


### PR DESCRIPTION
Fixes the incorrectly formed string for the case when there are no additional stacks chosen. In the current implementation the string 'railyard hash -b <self.base> ' is formed with the trailing space. When applying `split` it returns list ['railyard', 'hash', '-b', '<self.base>', '']. The last element of the list is passed to subprocess as the empty argument, and `railyard` CLI fails with `Error: Unexpected argument:`. As a result `tag` variable is not set in line 42 and spawn fails.

Fixes #91 