### PR TITLE
Notebook 0.7.0

### DIFF
--- a/deploy/docker/notebook/stacks/Dockerfile.template
+++ b/deploy/docker/notebook/stacks/Dockerfile.template
@@ -88,10 +88,6 @@ RUN cd /tmp && \
 # Installation scripts
 {% for s in scripts %}{{ s | dockerfileBlock('RUN') | safe }}{% endfor %}
 
-RUN jupyter labextension install --no-build {% for package in labextensions %}{{ package.key }}{% if package.value %}@{{package.value}}{% endif %} {% endfor %}&& \
-    jupyter lab build --dev-build=False && \
-    npm cache clean --force
-
 # Add symbolic link to the shared filesystem
 RUN ln -s /opt/shared shared
 

--- a/deploy/docker/notebook/stacks/Dockerfile.template
+++ b/deploy/docker/notebook/stacks/Dockerfile.template
@@ -30,13 +30,12 @@ RUN apt-get update && \
     apt-get -y install software-properties-common && \
     add-apt-repository ppa:apt-fast/stable && \
     apt-get update && \
-    apt-get -y install apt-fast && \
+    apt-get -y install apt-fast locales && \
     apt-fast update && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen && \
     apt-fast install -yq --no-install-recommends {% for package in apt %}{{ package.key }} {% endfor %} && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen
+    rm -rf /var/lib/apt/lists/*    
 
 # Create NB_USER wtih name jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.

--- a/deploy/docker/notebook/stacks/Dockerfile.template
+++ b/deploy/docker/notebook/stacks/Dockerfile.template
@@ -60,7 +60,7 @@ RUN mkdir /home/$NB_USER/work && \
 # Clear all temporary and auxiliary files to minimize image size
 RUN cd /tmp && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "0dba759b8ecfc8948f626fa18785e3d8 *Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
+    echo "${MINICONDA_INSTALLER_HASHSUM}  Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
     rm Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
@@ -68,12 +68,12 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
     $CONDA_DIR/bin/conda config --system --set channel_priority strict && \
-    $CONDA_DIR/bin/conda install pycryptosat && \
-    $CONDA_DIR/bin/conda install -y {% for package in conda %}{{ package.key }}{% if package.value %}={{package.value}}{% endif %} {% endfor %}&& \
+    $CONDA_DIR/bin/conda install mamba -n base -c conda-forge && \
+    mamba install -y {% for package in conda %}{{ package.key }}{% if package.value %}={{package.value}}{% endif %} {% endfor %}&& \
     pip install {% for package in pip %}{{ package.key }}{% if package.value %}=={{package.value}}{% endif %} {% endfor %}&& \
     $CONDA_DIR/bin/conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     $CONDA_DIR/bin/conda list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
-    npm cache clean --force && \
+#     npm cache clean --force && \
     jupyter notebook --generate-config && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     conda clean --all -f -y && \

--- a/deploy/docker/notebook/stacks/Dockerfile.template
+++ b/deploy/docker/notebook/stacks/Dockerfile.template
@@ -73,7 +73,7 @@ RUN cd /tmp && \
     pip install {% for package in pip %}{{ package.key }}{% if package.value %}=={{package.value}}{% endif %} {% endfor %}&& \
     $CONDA_DIR/bin/conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     $CONDA_DIR/bin/conda list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
-#     npm cache clean --force && \
+    npm cache clean --force && \
     jupyter notebook --generate-config && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     conda clean --all -f -y && \

--- a/deploy/docker/notebook/stacks/Dockerfile.template
+++ b/deploy/docker/notebook/stacks/Dockerfile.template
@@ -22,6 +22,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 {% set indent = joiner(' \\\n    ') %}ENV {% for v in env %}{{ indent() }}{{ v.key }}={% if v.value %}{{v.value}}{% endif %}{% endfor %}
 
+{% set indent = joiner(':') %}ENV PATH={% for v in path %}{{ indent() }}{{ v.key }}{% endfor %}:$PATH
+
 USER root
 
 RUN apt-get update && \

--- a/deploy/docker/notebook/stacks/Python-datascience.yaml
+++ b/deploy/docker/notebook/stacks/Python-datascience.yaml
@@ -1,22 +1,22 @@
 name: Python-Datascience
 conda:
-  - pandas: 0.25*
+  - pandas: 1.2*
   - blas: "*=openblas"
-  - scikit-learn: 0.21*
-  - scikit-image: 0.16*
-  - sympy: 1.4*
+  - scikit-learn: 0.24*
+  - scikit-image: 0.18*
+  - sympy: 1.8*
   - cython: 0.29*
   - patsy: 0.5*
-  - cloudpickle: 1.2*
+  - cloudpickle: 1.6*
   - dill: 0.3*
-  - statsmodels: 0.10*
-  - dvc: 0.66*
-  - beautifulsoup4: 4.8*
-  - protobuf: 3.8*
-  - xlrd: 1.2*
-  - numba: 0.46*
-  - sqlalchemy: 1.3*
-  - hdf5: 1.10*
-  - h5py: 2.9*
+  - statsmodels: 0.12*
+  - dvc: 2.3*
+  - beautifulsoup4: 4.9*
+  - protobuf: 3.17*
+  - xlrd: 2*
+  - numba: 0.53*
+  - sqlalchemy: 1.4*
+  - hdf5: 1*
+  - h5py: 3*
 pip:
-  - opencv-python: 4.1.1.26
+  - opencv-python: 4.5.2.54

--- a/deploy/docker/notebook/stacks/Python-datascience.yaml
+++ b/deploy/docker/notebook/stacks/Python-datascience.yaml
@@ -12,7 +12,6 @@ conda:
   - statsmodels: 0.12*
   - dvc: 2.3*
   - beautifulsoup4: 4.9*
-  - protobuf: 3.17*
   - xlrd: 2*
   - numba: 0.53*
   - sqlalchemy: 1.4*

--- a/deploy/docker/notebook/stacks/Python-dataviz.yaml
+++ b/deploy/docker/notebook/stacks/Python-dataviz.yaml
@@ -1,27 +1,23 @@
 name: Python-Dataviz
 conda:
-  - gnuplot: 5*
-  - bokeh: 1*
-  - holoviews: 1.12*
-  - hvplot: 0.5*
-  - panel: 0.6*
-  - voila: 0.1.20*
-  - itkwidgets: 0.22*
-  - plotly: 4.3*
-  - seaborn: 0.9*
+  - gnuplot: 5.4*
+  - bokeh: 2.3*
+  - jupyter_bokeh: 3.0*
+  - holoviews: 1.14*
+  - hvplot: 0.7*
+  - panel: 0.11*
+  - voila: 0.2.10*
+  # - itkwidgets: 0.32* # not supported in py3.9
+  - plotly: 4.14*
+  - seaborn: 0.11*
   - vincent: 0.4*
-  - altair: 3.2*
-  - vega_datasets: 0.7*
-  - bqplot: 0.11*
-  - pythreejs: 2.1*
-pip:
+  - altair: 4.1*
+  - vega_datasets: 0.9*
+  - bqplot: 0.12*
+  - pythreejs: 2.3*
   - py4j: 0.10.9
   - beakerx: 1.4.1
-labextensions:
-  - "@pyviz/jupyterlab_pyviz": 0.8.0
-  - jupyterlab_bokeh: 1.0.0
-  - "@jupyter-voila/jupyterlab-preview": 0.1.3
-  - bqplot: 0.4.9
-  - itkwidgets: 0.22.0
-  - jupyter-threejs: 2.1.1
-  - beakerx-jupyterlab: 1.4.1
+  - pyviz_comms: 2.0*
+# labextensions:
+#   - itkwidgets: 0.22.0
+#   - beakerx-jupyterlab: 1.4.1 # not updated for JLab 3

--- a/deploy/docker/notebook/stacks/Python-dataviz.yaml
+++ b/deploy/docker/notebook/stacks/Python-dataviz.yaml
@@ -16,7 +16,7 @@ conda:
   - bqplot: 0.12*
   - pythreejs: 2.3*
   - py4j: 0.10.9
-  - beakerx: 1.4.1
+  # - beakerx: 1.4.1 #causing conflicts with Java stack; creates multiple additional language kernels
   - pyviz_comms: 2.0*
 # labextensions:
 #   - itkwidgets: 0.22.0

--- a/deploy/docker/notebook/stacks/R.yaml
+++ b/deploy/docker/notebook/stacks/R.yaml
@@ -3,36 +3,36 @@ apt:
   - fonts-dejavu
   - gfortran
   - gcc
+  - libicu-dev
 conda:
-  - rpy2: 2.9*
-  - r-base: 3.6*
-  - r-irkernel: 1.0.2
-  - r-plyr: 1.8.4
-  - r-devtools: 2.2.1
-  - r-tidyverse: 1.2.1
-  - r-shiny: 1.4.0
-  - r-rmarkdown: 1.16
-  - r-forecast: 8.9
-  - r-rsqlite: 2.1.2
-  - r-reshape2: 1.4.3
-  - r-caret: "6.0_84"
-  - r-rcurl: "1.95_4.12"
-  - r-crayon: 1.3.4
+  - rpy2: 3.4.5
+  - r-irkernel: 1.2
+  - r-plyr: 1.8.6
+  - r-devtools: 2.4.1
+  - r-tidyverse: 1.3.1
+  - r-shiny: 1.6.0
+  - r-rmarkdown: 2.8
+  - r-forecast: 8.14
+  - r-rsqlite: 2.2.5
+  - r-reshape2: 1.4.4
+  - r-caret: "6.0_88"
+  - r-rcurl: "1.98_1.3"
+  - r-crayon: 1.4.1
   - r-randomforest: "4.6_14"
-  - r-htmltools: 0.4.0
-  - r-sparklyr: 1.0.4
-  - r-htmlwidgets: 1.5.1
-  - r-hexbin: 1.27.3
+  - r-htmltools: 0.5.1.1
+  - r-sparklyr: 1.6.2
+  - r-htmlwidgets: 1.5.3
+  - r-hexbin: 1.28.2
   - r-feather: 0.3.5
-  - r-highcharter: 0.7.0
+  - r-highcharter: 0.8.2
   - r-dygraphs: 1.1.1.6
-  - r-visnetwork: 2.0.8
+  - r-visnetwork: 2.0.9
   - r-d3heatmap: 0.6.1.2
-  - r-plotly: 4.9.1
-  - r-rbokeh
+  - r-plotly: 4.9.3
+  - r-rbokeh: 0.5.1
   - r-networkd3: 0.4
-  - r-dt: "0.10"
-  - r-threejs: 0.3.1
+  - r-dt: 0.18
+  - r-threejs: 0.3.3
   - r-rglwidget: 0.2.1
-  - r-stringi: 1.4.3
-  - sos-r: 0.19*
+  - r-stringi: 1.6.2
+  - sos-r: 0.19.6

--- a/deploy/docker/notebook/stacks/base.yaml
+++ b/deploy/docker/notebook/stacks/base.yaml
@@ -68,17 +68,12 @@ conda:
   - jupyterlab-transient-display-data: 0.4.0
 pip:
   - facets-overview: 1.0.0
-  - jupyterlab-wipp: 0.3.0
+  - jupyterlab-wipp: 1.2.0
   - bfio: 2.0.7
   - filepattern: 1.4.6
   - jupyterlab-spreadsheet-editor: 0.6.0
   - jupyterlab-quickopen: 1.0.0
   - aquirdturtle-collapsible-headings: 3.1.0
-labextensions:
-  - jupyterlab_wipp: 1.1.0
-scripts:
-  - jupyterlab_wipp_activate: |
-      jupyter serverextension enable --py jupyterlab_wipp
 addfiles:
   - fix-permissions:
       destination: /usr/local/bin/fix-permissions

--- a/deploy/docker/notebook/stacks/base.yaml
+++ b/deploy/docker/notebook/stacks/base.yaml
@@ -69,7 +69,7 @@ conda:
 pip:
   - facets-overview: 1.0.0
   - jupyterlab-wipp: 0.3.0
-  - bfio: 2.1.8
+  - bfio: 2.0.7
   - filepattern: 1.4.6
   - jupyterlab-spreadsheet-editor: 0.6.0
   - jupyterlab-quickopen: 1.0.0

--- a/deploy/docker/notebook/stacks/base.yaml
+++ b/deploy/docker/notebook/stacks/base.yaml
@@ -1,5 +1,5 @@
 name: base
-base: "ubuntu:bionic-20190612@sha256:9b1702dcfe32c873a770a32cfd306dd7fc1c4fd134adfb783db68defc8894b3c"
+base: "ubuntu:focal-20210416@sha256:86ac87f73641c920fb42cc9612d4fb57b5626b56ea2a19b894d0673fd5b4f2e9"
 env:
   - PATH: $CONDA_DIR/bin:$PATH
   - HOME: /home/$NB_USER
@@ -32,7 +32,7 @@ apt:
   - ffmpeg
   - ssh
   - tzdata
-  - libssl1.0.0
+  - libssl1.1
   - libssl-dev
   - curl
   - procps
@@ -41,46 +41,46 @@ conda_channels:
   - conda-forge
 conda:
   - tini: 0.18.0
-  - notebook: 6.0.1
-  - jupyterhub
-  - jupyterlab: 1.2.3
-  - ipywidgets: 7.5*
-  - jupyter-archive: 0.5.5
-  - numexpr: 2.6*
-  - matplotlib-base: 3.1*
-  - scipy: 1.3*
-  - feather-format
-  - nbformat
-  - sos-notebook: 0.20*
-  - sos-python: 0.18*
-  - nbdime: 1.1*
-pip:
-  - facets-overview: 1.0.0
-  - jupyterlab-quickopen: 0.3.0
-  - jupyterlab-git: 0.9.0
-  - jupyterlab-wipp: 0.3.0
-  - nbresuse
-  - bfio: 1.3.6
-  - filepattern: 1.2.4
-labextensions:
-  - "@jupyter-widgets/jupyterlab-manager": 1.1.0
-  - transient-display-data: 0.3.0
-  - jupyterlab-sos: 0.5.3
-  - "@jupyterlab/hub-extension": 1.1.2
-  - "@webio/jupyter-lab-provider"
-  - "@aquirdturtle/collapsible_headings": 0.5.0
-  - jupyterlab-python-file: 0.3.0
-  - "@parente/jupyterlab-quickopen": 0.3.0
-  - jupyterlab-spreadsheet: 0.2.0
-  - "@krassowski/jupyterlab_go_to_definition": 0.7.1
-  - jupyterlab_wipp: 0.3.0
-  - jupyterlab-topbar-extension: 0.4.0
-  - jupyterlab-system-monitor: 0.4.1
-scripts:
-  - sos_kernel_install: |
-      python -m sos_notebook.install
-  - jupyterlab_wipp_activate: |
-      jupyter serverextension enable --py jupyterlab_wipp
+  - notebook: 6.4.0
+  # - jupyterhub
+  - jupyterlab: 3.0.16
+  # - ipywidgets: 7.5*
+  # - jupyter-archive: 0.5.5
+  # - numexpr: 2.6*
+  # - matplotlib-base: 3.1*
+  # - scipy: 1.3*
+  # - feather-format
+  # - nbformat
+  # - sos-notebook: 0.20*
+  # - sos-python: 0.18*
+  # - nbdime: 1.1*
+# pip:
+  # - facets-overview: 1.0.0
+  # - jupyterlab-quickopen: 0.3.0
+  # - jupyterlab-git: 0.9.0
+  # - jupyterlab-wipp: 0.3.0
+  # - nbresuse
+  # - bfio: 2.1.7
+  # - filepattern: 1.2.4
+# labextensions:
+  # - "@jupyter-widgets/jupyterlab-manager": 1.1.0
+  # - transient-display-data: 0.3.0
+  # - jupyterlab-sos: 0.5.3
+  # - "@jupyterlab/hub-extension": 1.1.2
+  # - "@webio/jupyter-lab-provider"
+  # - "@aquirdturtle/collapsible_headings": 0.5.0
+  # - jupyterlab-python-file: 0.3.0
+  # - "@parente/jupyterlab-quickopen": 0.3.0
+  # - jupyterlab-spreadsheet: 0.2.0
+  # - "@krassowski/jupyterlab_go_to_definition": 0.7.1
+  # - jupyterlab_wipp: 0.3.0
+  # - jupyterlab-topbar-extension: 0.4.0
+  # - jupyterlab-system-monitor: 0.4.1
+# scripts:
+  # - sos_kernel_install: |
+  #     python -m sos_notebook.install
+  # - jupyterlab_wipp_activate: |
+  #     jupyter serverextension enable --py jupyterlab_wipp
 addfiles:
   - fix-permissions:
       destination: /usr/local/bin/fix-permissions

--- a/deploy/docker/notebook/stacks/base.yaml
+++ b/deploy/docker/notebook/stacks/base.yaml
@@ -3,8 +3,9 @@ base: "ubuntu:focal-20210416@sha256:86ac87f73641c920fb42cc9612d4fb57b5626b56ea2a
 env:
   - PATH: $CONDA_DIR/bin:$PATH
   - HOME: /home/$NB_USER
-  - MINICONDA_VERSION: 4.7.12
-  - CONDA_VERSION: 4.8.2
+  - MINICONDA_VERSION: py39_4.9.2
+  - MINICONDA_INSTALLER_HASHSUM: b4e46fcc8029e2cfa731b788f25b1d36
+  - CONDA_VERSION: 4.9.2
   - XDG_CACHE_HOME: /home/$NB_USER/.cache/
 apt:
   - wget
@@ -42,45 +43,41 @@ conda_channels:
 conda:
   - tini: 0.18.0
   - notebook: 6.4.0
-  # - jupyterhub
+  - jupyterhub
   - jupyterlab: 3.0.16
-  # - ipywidgets: 7.5*
-  # - jupyter-archive: 0.5.5
-  # - numexpr: 2.6*
-  # - matplotlib-base: 3.1*
-  # - scipy: 1.3*
-  # - feather-format
-  # - nbformat
-  # - sos-notebook: 0.20*
-  # - sos-python: 0.18*
-  # - nbdime: 1.1*
-# pip:
-  # - facets-overview: 1.0.0
-  # - jupyterlab-quickopen: 0.3.0
-  # - jupyterlab-git: 0.9.0
-  # - jupyterlab-wipp: 0.3.0
-  # - nbresuse
-  # - bfio: 2.1.7
-  # - filepattern: 1.2.4
-# labextensions:
-  # - "@jupyter-widgets/jupyterlab-manager": 1.1.0
-  # - transient-display-data: 0.3.0
-  # - jupyterlab-sos: 0.5.3
-  # - "@jupyterlab/hub-extension": 1.1.2
-  # - "@webio/jupyter-lab-provider"
-  # - "@aquirdturtle/collapsible_headings": 0.5.0
-  # - jupyterlab-python-file: 0.3.0
-  # - "@parente/jupyterlab-quickopen": 0.3.0
-  # - jupyterlab-spreadsheet: 0.2.0
-  # - "@krassowski/jupyterlab_go_to_definition": 0.7.1
-  # - jupyterlab_wipp: 0.3.0
-  # - jupyterlab-topbar-extension: 0.4.0
-  # - jupyterlab-system-monitor: 0.4.1
-# scripts:
-  # - sos_kernel_install: |
-  #     python -m sos_notebook.install
-  # - jupyterlab_wipp_activate: |
-  #     jupyter serverextension enable --py jupyterlab_wipp
+  - ipywidgets: 7.6*
+  - jupyter-archive: 3.0.1
+  - numexpr: 2.7*
+  - matplotlib-base: 3.4*
+  - scipy: 1.6*
+  - feather-format
+  - nbformat
+  - sos-notebook: 0.22*
+  - jupyterlab-sos: 0.8.1
+  - sos-papermill: 0.2.1
+  - sos-python: 0.18*
+  - nbdime: 3.1*
+  - jupyterlab-git: 0.30*
+  - jupyterlab-topbar: 0.6.1
+  - jupyterlab-python-file: 0.5.2
+  - ipywidgets: 7.6.3
+  - jupyterlab-lsp: 3.7.0
+  - python-lsp-server
+  - jupyterlab-system-monitor: 0.8.0
+  - jupyterlab-transient-display-data: 0.4.0
+pip:
+  - facets-overview: 1.0.0
+  - jupyterlab-wipp: 0.3.0
+  - bfio: 2.1.8
+  - filepattern: 1.4.6
+  - jupyterlab-spreadsheet-editor: 0.6.0
+  - jupyterlab-quickopen: 1.0.0
+  - aquirdturtle-collapsible-headings: 3.1.0
+labextensions:
+  - jupyterlab_wipp: 1.1.0
+scripts:
+  - jupyterlab_wipp_activate: |
+      jupyter serverextension enable --py jupyterlab_wipp
 addfiles:
   - fix-permissions:
       destination: /usr/local/bin/fix-permissions

--- a/deploy/docker/notebook/stacks/base.yaml
+++ b/deploy/docker/notebook/stacks/base.yaml
@@ -1,12 +1,13 @@
 name: base
 base: "ubuntu:focal-20210416@sha256:86ac87f73641c920fb42cc9612d4fb57b5626b56ea2a19b894d0673fd5b4f2e9"
 env:
-  - PATH: $CONDA_DIR/bin:$PATH
   - HOME: /home/$NB_USER
   - MINICONDA_VERSION: py39_4.9.2
   - MINICONDA_INSTALLER_HASHSUM: b4e46fcc8029e2cfa731b788f25b1d36
   - CONDA_VERSION: 4.9.2
   - XDG_CACHE_HOME: /home/$NB_USER/.cache/
+path:
+  - $CONDA_DIR/bin
 apt:
   - wget
   - bzip2
@@ -50,9 +51,6 @@ conda:
   - numexpr: 2.7*
   - matplotlib-base: 3.4*
   - scipy: 1.6*
-  # - libprotobuf: 3.11.*
-  # - arrow-cpp: 4.0.*
-  # - pyarrow: 4.0.*
   - feather-format
   - nbformat
   - sos-notebook: 0.22*

--- a/deploy/docker/notebook/stacks/base.yaml
+++ b/deploy/docker/notebook/stacks/base.yaml
@@ -50,7 +50,10 @@ conda:
   - numexpr: 2.7*
   - matplotlib-base: 3.4*
   - scipy: 1.6*
-  # - feather-format
+  # - libprotobuf: 3.11.*
+  # - arrow-cpp: 4.0.*
+  # - pyarrow: 4.0.*
+  - feather-format
   - nbformat
   - sos-notebook: 0.22*
   - jupyterlab-sos: 0.8.1

--- a/deploy/docker/notebook/stacks/base.yaml
+++ b/deploy/docker/notebook/stacks/base.yaml
@@ -50,7 +50,7 @@ conda:
   - numexpr: 2.7*
   - matplotlib-base: 3.4*
   - scipy: 1.6*
-  - feather-format
+  # - feather-format
   - nbformat
   - sos-notebook: 0.22*
   - jupyterlab-sos: 0.8.1

--- a/deploy/docker/notebook/stacks/base_gpu.yaml
+++ b/deploy/docker/notebook/stacks/base_gpu.yaml
@@ -68,17 +68,12 @@ conda:
   - jupyterlab-transient-display-data: 0.4.0
 pip:
   - facets-overview: 1.0.0
-  - jupyterlab-wipp: 0.3.0
+  - jupyterlab-wipp: 1.2.0
   - bfio: 2.0.7
   - filepattern: 1.4.6
   - jupyterlab-spreadsheet-editor: 0.6.0
   - jupyterlab-quickopen: 1.0.0
   - aquirdturtle-collapsible-headings: 3.1.0
-labextensions:
-  - jupyterlab_wipp: 1.1.0
-scripts:
-  - jupyterlab_wipp_activate: |
-      jupyter serverextension enable --py jupyterlab_wipp
 addfiles:
   - fix-permissions:
       destination: /usr/local/bin/fix-permissions

--- a/deploy/docker/notebook/stacks/base_gpu.yaml
+++ b/deploy/docker/notebook/stacks/base_gpu.yaml
@@ -69,7 +69,7 @@ conda:
 pip:
   - facets-overview: 1.0.0
   - jupyterlab-wipp: 0.3.0
-  - bfio: 2.1.8
+  - bfio: 2.0.7
   - filepattern: 1.4.6
   - jupyterlab-spreadsheet-editor: 0.6.0
   - jupyterlab-quickopen: 1.0.0

--- a/deploy/docker/notebook/stacks/base_gpu.yaml
+++ b/deploy/docker/notebook/stacks/base_gpu.yaml
@@ -1,11 +1,13 @@
 name: base_gpu
-base: "labshare/polus-cuda-base:bionic-20190612-cuda-10-1@sha256:06db805859a79b556687752d179fab532c87a5ee551d9350f223a0704fd7b25e"
+base: "labshare/polus-cuda-base:focal-20210416-cuda-11-3@sha256:92c5f7c88f1cc2661a2a652733ee766f41c03b2d9a33b206c3d47d6bf81a6517"
 env:
-  - PATH: $CONDA_DIR/bin:$PATH
   - HOME: /home/$NB_USER
-  - MINICONDA_VERSION: 4.7.12
-  - CONDA_VERSION: 4.8.2
+  - MINICONDA_VERSION: py39_4.9.2
+  - MINICONDA_INSTALLER_HASHSUM: b4e46fcc8029e2cfa731b788f25b1d36
+  - CONDA_VERSION: 4.9.2
   - XDG_CACHE_HOME: /home/$NB_USER/.cache/
+path:
+  - $CONDA_DIR/bin
 apt:
   - wget
   - bzip2
@@ -32,7 +34,7 @@ apt:
   - ffmpeg
   - ssh
   - tzdata
-  - libssl1.0.0
+  - libssl1.1
   - libssl-dev
   - curl
   - procps
@@ -41,42 +43,40 @@ conda_channels:
   - conda-forge
 conda:
   - tini: 0.18.0
-  - notebook: 6.0.1
+  - notebook: 6.4.0
   - jupyterhub
-  - jupyterlab: 1.2.3
-  - ipywidgets: 7.5*
-  - jupyter-archive: 0.5.5
-  - numexpr: 2.6*
-  - matplotlib-base: 3.1*
-  - scipy: 1.3*
+  - jupyterlab: 3.0.16
+  - ipywidgets: 7.6*
+  - jupyter-archive: 3.0.1
+  - numexpr: 2.7*
+  - matplotlib-base: 3.4*
+  - scipy: 1.6*
   - feather-format
   - nbformat
-  - sos-notebook: 0.20*
+  - sos-notebook: 0.22*
+  - jupyterlab-sos: 0.8.1
+  - sos-papermill: 0.2.1
   - sos-python: 0.18*
-  - nbdime: 1.1*
+  - nbdime: 3.1*
+  - jupyterlab-git: 0.30*
+  - jupyterlab-topbar: 0.6.1
+  - jupyterlab-python-file: 0.5.2
+  - ipywidgets: 7.6.3
+  - jupyterlab-lsp: 3.7.0
+  - python-lsp-server
+  - jupyterlab-system-monitor: 0.8.0
+  - jupyterlab-transient-display-data: 0.4.0
 pip:
   - facets-overview: 1.0.0
-  - jupyterlab-quickopen: 0.3.0
-  - jupyterlab-git: 0.9.0
   - jupyterlab-wipp: 0.3.0
-  - nbresuse
+  - bfio: 2.1.8
+  - filepattern: 1.4.6
+  - jupyterlab-spreadsheet-editor: 0.6.0
+  - jupyterlab-quickopen: 1.0.0
+  - aquirdturtle-collapsible-headings: 3.1.0
 labextensions:
-  - "@jupyter-widgets/jupyterlab-manager": 1.1.0
-  - transient-display-data: 0.3.0
-  - jupyterlab-sos: 0.5.3
-  - "@jupyterlab/hub-extension": 1.1.2
-  - "@webio/jupyter-lab-provider"
-  - "@aquirdturtle/collapsible_headings": 0.5.0
-  - jupyterlab-python-file: 0.3.0
-  - "@parente/jupyterlab-quickopen": 0.3.0
-  - jupyterlab-spreadsheet: 0.2.0
-  - "@krassowski/jupyterlab_go_to_definition": 0.7.1
-  - jupyterlab_wipp: 0.3.0
-  - jupyterlab-topbar-extension: 0.4.0
-  - jupyterlab-system-monitor: 0.4.1
+  - jupyterlab_wipp: 1.1.0
 scripts:
-  - sos_kernel_install: |
-      python -m sos_notebook.install
   - jupyterlab_wipp_activate: |
       jupyter serverextension enable --py jupyterlab_wipp
 addfiles:

--- a/deploy/docker/notebook/stacks/bash.yaml
+++ b/deploy/docker/notebook/stacks/bash.yaml
@@ -1,7 +1,8 @@
 name: 
 conda:
-  - bash_kernel
-  - sos-bash: 0.19*
+  - bash_kernel: 0.7*
+pip:
+  - sos-bash: 0.20.0
 scripts:
   - bash_kernel_install: |
       python -m bash_kernel.install --user

--- a/deploy/docker/notebook/stacks/cpp.yaml
+++ b/deploy/docker/notebook/stacks/cpp.yaml
@@ -2,10 +2,10 @@ name: cpp
 apt:
   - gcc
 conda:
-  - xeus-cling: 0.7*
-  - xwidgets: 0.19*
-  - xtensor: 0.20*
-  - xtl: 0.6*
-  - xframe: 0.2*
+  - xeus-cling: 0.11.0
+  - xwidgets: 0.24.2
+  - xtensor: 0.21.10
+  - xtl: 0.6.23
+  - xframe: 0.3.0
 pip:
   - sos-xeus-cling: 0.1.0

--- a/deploy/docker/notebook/stacks/fastai.yaml
+++ b/deploy/docker/notebook/stacks/fastai.yaml
@@ -1,3 +1,3 @@
 name: fastai
 pip:
-  - fastai: "1.0.60"
+  - fastai: 2.4

--- a/deploy/docker/notebook/stacks/java.yaml
+++ b/deploy/docker/notebook/stacks/java.yaml
@@ -6,7 +6,7 @@ env:
 apt:
   - openjdk-8-jdk
   - openjdk-11-jdk
-  - maven=3.6.0-1~18.04.1
+  - maven=3.6.3-1
 pip: 
   - sos-java: 0.1.0
 scripts:

--- a/deploy/docker/notebook/stacks/julia.yaml
+++ b/deploy/docker/notebook/stacks/julia.yaml
@@ -5,6 +5,8 @@ env:
 conda: 
   - julia: 1.0.3
   - sos-julia: 0.18*
+labextensions:
+  - "@webio/jupyter-lab-provider"
 scripts:
   - julia: |
       julia -e 'import Pkg; Pkg.update()' && \

--- a/deploy/docker/notebook/stacks/julia.yaml
+++ b/deploy/docker/notebook/stacks/julia.yaml
@@ -1,19 +1,35 @@
 name: julia
 env:
-  - JULIA_DEPOT_PATH: /opt/julia
-  - JULIA_PKGDIR: /opt/julia
-conda: 
-  - julia: 1.0.3
-  - sos-julia: 0.18*
-labextensions:
-  - "@webio/jupyter-lab-provider"
+  - JULIA_PATH: /opt/julia
+  - JULIA_GPG: 3673DF529D9049477F76B37566E3C7DC03D6E495
+  - JULIA_VERSION: 1.6.1
+  - INSTALLER_HASHSUM: 7c888adec3ea42afbfed2ce756ce1164a570d50fa7506c3f2e1e2cbc49d52506
+pip: 
+  - sos-julia: 0.18.5
+path:
+  - $JULIA_PATH/bin
+apt:
+  - gnupg
+  - dirmngr
 scripts:
   - julia: |
+      folder="$(echo "$JULIA_VERSION" | cut -d. -f1-2)" && \
+      curl -fL -o julia.tar.gz.asc "https://julialang-s3.julialang.org/bin/linux/x64/${folder}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz.asc" && \
+      curl -fL -o julia.tar.gz     "https://julialang-s3.julialang.org/bin/linux/x64/${folder}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" && \
+      echo "${INSTALLER_HASHSUM} *julia.tar.gz" | sha256sum -c - && \
+      export GNUPGHOME="$(mktemp -d)" && \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG" && \
+      gpg --batch --verify julia.tar.gz.asc julia.tar.gz && \
+      command -v gpgconf > /dev/null && gpgconf --kill all && \
+      rm -rf "$GNUPGHOME" julia.tar.gz.asc && \
+      mkdir "$JULIA_PATH" && \
+      tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1 && \
+      rm julia.tar.gz && \
       julia -e 'import Pkg; Pkg.update()' && \
       julia -e "using Pkg; \
                 pkg\"add Feather DataFrames NamedArrays RDatasets IJulia InstantiateFromURL HDF5 https://github.com/probcomp/Gen\";\
                 pkg\"precompile\"" && \
       # move kernelspec out of home \
-      mv $HOME/.local/share/jupyter/kernels/julia-1.0/kernel.json $CONDA_DIR/share/jupyter/kernels/julia-1.0/kernel.json && \
+      mv $HOME/.local/share/jupyter/kernels/julia-1.6 $CONDA_DIR/share/jupyter/kernels/julia-1.6 && \
       rm -rf $HOME/.local && \
-      fix-permissions $JULIA_PKGDIR $CONDA_DIR/share/jupyter
+      fix-permissions $JULIA_PATH $CONDA_DIR/share/jupyter

--- a/deploy/docker/notebook/stacks/julia.yaml
+++ b/deploy/docker/notebook/stacks/julia.yaml
@@ -27,7 +27,7 @@ scripts:
       rm julia.tar.gz && \
       julia -e 'import Pkg; Pkg.update()' && \
       julia -e "using Pkg; \
-                pkg\"add Feather DataFrames NamedArrays RDatasets IJulia InstantiateFromURL HDF5 https://github.com/probcomp/Gen\";\
+                pkg\"add Feather DataFrames NamedArrays RDatasets IJulia InstantiateFromURL HDF5 LanguageServer https://github.com/probcomp/Gen\";\
                 pkg\"precompile\"" && \
       # move kernelspec out of home \
       mv $HOME/.local/share/jupyter/kernels/julia-1.6 $CONDA_DIR/share/jupyter/kernels/julia-1.6 && \

--- a/deploy/docker/notebook/stacks/latex.yaml
+++ b/deploy/docker/notebook/stacks/latex.yaml
@@ -7,9 +7,4 @@ conda:
   - chktex
 scripts:
   - latex: |
-      git clone https://github.com/joequant/jupyterlab-latex.git /opt/jupyterlab_latex && \
-      pip install /opt/jupyterlab_latex && \
-      jupyter serverextension enable --sys-prefix jupyterlab_latex && \
-      jlpm install --cwd /opt/jupyterlab_latex && \
-      jlpm run --cwd=/opt/jupyterlab_latex build && \
-      jupyter labextension install /opt/jupyterlab_latex
+      pip install git+git://github.com/ktaletsk/jupyterlab-latex.git@1e79ba29b8c7e51205661f874ff6d7ec90825021

--- a/deploy/docker/notebook/stacks/latex.yaml
+++ b/deploy/docker/notebook/stacks/latex.yaml
@@ -2,7 +2,14 @@ name: latex
 apt:
   - texlive-xetex
   - texlive-fonts-recommended
-pip:
-  - jupyterlab_latex: 1.0.0
-labextensions:
-  - "@jupyterlab/latex": 1.0.0
+conda:
+  - texlab
+  - chktex
+scripts:
+  - latex: |
+      git clone https://github.com/joequant/jupyterlab-latex.git /opt/jupyterlab_latex && \
+      pip install /opt/jupyterlab_latex && \
+      jupyter serverextension enable --sys-prefix jupyterlab_latex && \
+      jlpm install --cwd /opt/jupyterlab_latex && \
+      jlpm run --cwd=/opt/jupyterlab_latex build && \
+      jupyter labextension install /opt/jupyterlab_latex

--- a/deploy/docker/notebook/stacks/octave.yaml
+++ b/deploy/docker/notebook/stacks/octave.yaml
@@ -4,7 +4,7 @@ apt:
 conda:
   - octave_kernel
 pip:
-  - sos-matlab: 0.18.3
+  - sos-matlab: 0.18.5
 scripts:
   - octave_kernel_install: |
       python -m octave_kernel install --user

--- a/deploy/docker/notebook/stacks/pytorch.yaml
+++ b/deploy/docker/notebook/stacks/pytorch.yaml
@@ -1,5 +1,4 @@
 name: pytorch
 pip:
-  - torch: 1.4.0
-  - torchvision: 0.5.0
-  - kornia: 0.2.0
+  - https://download.pytorch.org/whl/cu111/torch-1.9.0%2Bcu111-cp39-cp39-linux_x86_64.whl
+  - https://download.pytorch.org/whl/cu111/torchvision-0.10.0%2Bcu111-cp39-cp39-linux_x86_64.whl

--- a/deploy/docker/notebook/stacks/scala.yaml
+++ b/deploy/docker/notebook/stacks/scala.yaml
@@ -1,19 +1,12 @@
 name: Scala
 env:
-  - SCALA_VERSION: 2.12.8
-  - ALMOND_VERSION: 0.6.0
-apt:
-  - scala
+  - SCALA_VERSION: 2.13
+  - ALMOND_VERSION: 0.11.1
 pip:
   - sos-scala: 0.18.0
 scripts:
   - scala: |
       curl -Lo coursier https://git.io/coursier-cli && \
       chmod +x coursier && \
-      ./coursier bootstrap \
-          -r jitpack \
-          -i user -I user:sh.almond:scala-kernel-api_$SCALA_VERSION:$ALMOND_VERSION \
-          sh.almond:scala-kernel_$SCALA_VERSION:$ALMOND_VERSION \
-          -o almond && \
-      ./almond --install && \
-      rm almond coursier
+      ./coursier launch --fork almond:$ALMOND_VERSION --scala $SCALA_VERSION -- --install && \
+      rm coursier

--- a/deploy/docker/notebook/stacks/template.yaml
+++ b/deploy/docker/notebook/stacks/template.yaml
@@ -9,8 +9,6 @@ conda:
   - 
 pip:
   - 
-labextensions:
-  - 
 scripts:
   - 
 addfiles:

--- a/deploy/docker/notebook/stacks/tensorflow.yaml
+++ b/deploy/docker/notebook/stacks/tensorflow.yaml
@@ -1,3 +1,3 @@
 name: tensorflow
 pip:
-  - tensorflow: 2.1.0
+  - tf-nightly-gpu: "2.7.0.dev20210630"


### PR DESCRIPTION
Major update
- Migrate to JupyterLab 3.0
- Update all extension to prebuilt(federated) model -- can be installed with pip/conda; no npm rebuild of jupyterLab required
- Add `env_path` key to track variables appended to $PATH
- Remove `labextension` key as we don't support source extension anymore
- Switch to `mamba` as a drop-in replacement for `conda` for faster installs
- Add [language server protocol extension](https://github.com/krassowski/jupyterlab-lsp) -- hover hints, variable refactoring, continuous hinting and autocompletion
- Updated packages