### PR TITLE
Helm Chart 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ SharePointSelfSignedCert.key
 .terraform
 .tfstate
 .tfstate.backup
+
+# Helm installed dependencies
+deploy/helm/charts
+deploy/helm/Chart.lock

--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -3,4 +3,9 @@ name: polus-jupyterhub
 description: Polus JupyterHub
 type: application
 version: 0.1.0
+dependencies:
+  - name: postgresql
+    version: ~10.16.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
 appVersion: "0.8.1.18"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: JupyterHub
+description: Polus JupyterHub
+type: application
+version: 0.1.0
+appVersion: "0.8.1.18"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: JupyterHub
+name: polus-jupyterhub
 description: Polus JupyterHub
 type: application
 version: 0.1.0

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,16 @@
+For a simple testing on AWS EKS, you can use the following chart values to simplify and remove most of the complexity.
+
+```
+hub:
+    storageClass: aws-efs
+    service:
+        type: LoadBalancer
+    ingress:
+        enabled: false
+    wipp:
+        enabled: false
+    polusNotebooksHub:
+        enabled: false
+postgresql:
+  enabled: true
+```

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,4 +1,6 @@
-For a simple testing on AWS EKS, you can use the following chart values to simplify and remove most of the complexity.
+## Test deployment
+
+For a simple testing, you can use the following chart values to simplify and remove most of the complexity.
 
 ```
 hub:
@@ -14,3 +16,11 @@ hub:
 postgresql:
   enabled: true
 ```
+
+## Production deployment
+
+### Configure ingress
+
+### Configure LS Auth
+
+Make sure that LS Auth redirect URL is pointing to ingress URL

--- a/deploy/helm/files/hub/jupyterhub-config.py
+++ b/deploy/helm/files/hub/jupyterhub-config.py
@@ -33,7 +33,7 @@ c.KubeSpawner.pod_name_template = f'{release_name}-{chart_name}-lab-{{username}}
 
 # Per-user storage configuration
 c.KubeSpawner.pvc_name_template = 'claim-{username}'
-c.KubeSpawner.storage_class = get_config("hub.storage.storageClass")
+c.KubeSpawner.storage_class = get_config("global.storageClass")
 c.KubeSpawner.storage_capacity = get_config("hub.storage.storagePerUser")
 c.KubeSpawner.storage_access_modes = ['ReadWriteOnce']
 c.KubeSpawner.storage_pvc_ensure = True

--- a/deploy/helm/files/hub/jupyterhub-config.py
+++ b/deploy/helm/files/hub/jupyterhub-config.py
@@ -137,23 +137,26 @@ else:
 c.JupyterHub.cleanup_servers=False
 c.JupyterHub.cookie_secret_file = '/srv/jupyterhub/jupyterhub_cookie_secret'
 
+if get_config("hub.auth.enabled"):
+    # Default authenticator in production is OAuth with LabShare
+    c.JupyterHub.authenticator_class = GenericOAuthenticator
+    OAUTH_CLIENT_ID = os.getenv('OAUTH_CLIENT_ID')
+    OAUTH_CLIENT_SECRET = os.getenv('OAUTH_CLIENT_SECRET')
+    ADMIN_USERS = os.getenv('ADMIN_USERS')
+    ADMIN_SERVICE_ACC = os.getenv('ADMIN_SERVICE_ACC')
 
-c.JupyterHub.authenticator_class = DummyAuthenticator
-# c.JupyterHub.authenticator_class = GenericOAuthenticator
-# OAUTH_CLIENT_ID = os.getenv('OAUTH_CLIENT_ID')
-# OAUTH_CLIENT_SECRET = os.getenv('OAUTH_CLIENT_SECRET')
-# ADMIN_USERS = os.getenv('ADMIN_USERS')
-# ADMIN_SERVICE_ACC = os.getenv('ADMIN_SERVICE_ACC')
+    c.Authenticator.admin_users = set(ADMIN_USERS.split(';'))
 
-# c.Authenticator.admin_users = set(ADMIN_USERS.split(';'))
-
-# c.GenericOAuthenticator.client_id = OAUTH_CLIENT_ID
-# c.GenericOAuthenticator.client_secret = OAUTH_CLIENT_SECRET
-# c.GenericOAuthenticator.username_key = "email"
-# c.GenericOAuthenticator.userdata_method = "GET"
-# c.GenericOAuthenticator.extra_params = dict(client_id=OAUTH_CLIENT_ID, client_secret=OAUTH_CLIENT_SECRET)
-# c.GenericOAuthenticator.basic_auth = False
-# c.GenericOAuthenticator.auto_login = True
+    c.GenericOAuthenticator.client_id = OAUTH_CLIENT_ID
+    c.GenericOAuthenticator.client_secret = OAUTH_CLIENT_SECRET
+    c.GenericOAuthenticator.username_key = "email"
+    c.GenericOAuthenticator.userdata_method = "GET"
+    c.GenericOAuthenticator.extra_params = dict(client_id=OAUTH_CLIENT_ID, client_secret=OAUTH_CLIENT_SECRET)
+    c.GenericOAuthenticator.basic_auth = False
+    c.GenericOAuthenticator.auto_login = True
+else:
+    # Fallback to DummyAuthenticator if no auth is configured
+    c.JupyterHub.authenticator_class = DummyAuthenticator
 
 # Read the users and groups backed up by config-wrapper
 try:

--- a/deploy/helm/files/hub/jupyterhub-config.py
+++ b/deploy/helm/files/hub/jupyterhub-config.py
@@ -1,0 +1,248 @@
+import os,sys
+import string
+import pickle
+import escapism
+from oauthenticator.generic import GenericOAuthenticator
+from jupyterhub.auth import DummyAuthenticator
+
+# Make sure that modules placed in the same directory as the jupyterhub config are added to the pythonpath
+configuration_directory = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, configuration_directory)
+
+from z2jh import (
+    get_config,
+    get_secret_value
+)
+
+wipp_enabled = get_config("hub.wipp.enabled")
+polus_notebooks_hub_enabled = get_config("hub.polusNotebooks.enabled")
+
+c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
+c.KubeSpawner.start_timeout=1000
+
+c.KubeSpawner.default_url = '/lab'
+c.KubeSpawner.uid = 1000 #uid 1000 corresponds to jovyan, uid 0 to root
+c.KubeSpawner.cmd = ['jupyter-labhub']
+c.KubeSpawner.args = ['--collaborative']
+c.KubeSpawner.working_dir = '/home/jovyan'
+c.KubeSpawner.service_account='jupyteruser-sa'
+c.KubeSpawner.singleuser_image_pull_policy= 'Always'
+
+# Per-user storage configuration
+c.KubeSpawner.pvc_name_template = 'claim-{username}'
+c.KubeSpawner.storage_class = get_config("hub.storageClass")
+c.KubeSpawner.storage_capacity = get_config("hub.storagePerUser")
+c.KubeSpawner.storage_access_modes = ['ReadWriteOnce']
+c.KubeSpawner.storage_pvc_ensure = True
+
+# Volumes to attach to Pod
+c.KubeSpawner.volumes = [
+    {
+        'name': 'volume-{username}',
+        'persistentVolumeClaim': {
+            'claimName': 'claim-{username}'
+        }
+    },
+    {
+        'name': 'shared-volume',
+        'persistentVolumeClaim': {
+            'claimName': get_config("hub.sharedNotebookStoragePVC")
+        }
+    },
+    {
+        'name': 'modules-volume',
+        'persistentVolumeClaim': {
+            'claimName': get_config("hub.modulesStoragePVC")
+        }
+    },
+    {
+        'name': 'wipp-volume',
+        'persistentVolumeClaim': {
+            'claimName': get_config("hub.wipp.storagePVC")
+        }
+    }
+]
+
+# Where to mount volumes
+c.KubeSpawner.volume_mounts = [
+    {
+        'mountPath': '/home/jovyan/work',
+        'name': 'volume-{username}'
+    },
+    {
+        'mountPath': '/opt/shared/notebooks',
+        'name': 'shared-volume'
+    },
+    {
+        'mountPath': '/opt/modules',
+        'name': 'modules-volume',
+        'readOnly': True
+    },
+    {
+        'mountPath': get_config("hub.wipp.mountPath"),
+        'name': 'wipp-volume'
+    }
+]
+
+c.KubeSpawner.image =  'labshare/polyglot-notebook:' + get_config("hub.notebookVersion")
+
+if polus_notebooks_hub_enabled:
+    c.KubeSpawner.profile_list = [
+        {
+            'display_name': 'JupyterLab',
+            'slug': 'jupyterlab',
+            'kubespawner_override': {
+                'image': c.KubeSpawner.image
+            }
+        },
+        {
+            'display_name': 'Streamlit Dashboard',
+            'slug': 'jhsingle-streamlit-variable',
+            'kubespawner_override': {
+                'image': 'polusai/hub-streamlit'
+            }
+        },
+        {
+            'display_name': 'Voila Dashboard',
+            'slug': 'jhsingle-voila-variable',
+            'kubespawner_override': {
+                'image': 'polusai/hub-voila'
+            }
+        }
+    ]
+
+c.JupyterHub.allow_named_servers=True
+c.JupyterHub.ip='0.0.0.0'
+c.JupyterHub.hub_ip='0.0.0.0'
+
+# Required for AWS
+c.JupyterHub.hub_connect_ip='jupyterhub-internal'
+
+# configure the hub db connection
+
+# Configure Postgres database
+# postgres_db = os.getenv('POSTGRES_DB')
+# postgres_user = os.getenv('POSTGRES_USER')
+# postgres_password = os.getenv('POSTGRES_PASSWORD')
+# c.JupyterHub.db_url = 'postgresql://' + postgres_user + ':' + postgres_password + '@' + 'jupyterhub-postgres-service' + '/' + postgres_db
+
+c.JupyterHub.cleanup_servers=False
+c.JupyterHub.cookie_secret_file = '/srv/jupyterhub/jupyterhub_cookie_secret'
+
+
+c.JupyterHub.authenticator_class = DummyAuthenticator
+# c.JupyterHub.authenticator_class = GenericOAuthenticator
+# OAUTH_CLIENT_ID = os.getenv('OAUTH_CLIENT_ID')
+# OAUTH_CLIENT_SECRET = os.getenv('OAUTH_CLIENT_SECRET')
+# ADMIN_USERS = os.getenv('ADMIN_USERS')
+# ADMIN_SERVICE_ACC = os.getenv('ADMIN_SERVICE_ACC')
+
+# c.Authenticator.admin_users = set(ADMIN_USERS.split(';'))
+
+# c.GenericOAuthenticator.client_id = OAUTH_CLIENT_ID
+# c.GenericOAuthenticator.client_secret = OAUTH_CLIENT_SECRET
+# c.GenericOAuthenticator.username_key = "email"
+# c.GenericOAuthenticator.userdata_method = "GET"
+# c.GenericOAuthenticator.extra_params = dict(client_id=OAUTH_CLIENT_ID, client_secret=OAUTH_CLIENT_SECRET)
+# c.GenericOAuthenticator.basic_auth = False
+# c.GenericOAuthenticator.auto_login = True
+
+# Read the users and groups backed up by config-wrapper
+try:
+    infile = open('users.pkl','rb')
+    users = pickle.load(infile)
+    infile.close()
+except:
+    users = []
+
+try:
+    infile = open('groups.pkl','rb')
+    groups_backup = pickle.load(infile)
+    infile.close()
+except:
+    groups_backup = {}
+
+# Create RBAC groups and roles
+groups = {}
+roles = []
+
+safe_chars = set(string.ascii_lowercase + string.digits)
+for user in users:
+    # Escape symbols not allowed in role and group names
+    safe_username = escapism.escape(user, safe=safe_chars).lower()
+
+    group = {f'server_sharing_{safe_username}': groups_backup.get(f'server_sharing_{safe_username}', [])}
+    groups.update(group)
+
+    sharing_role = {
+        'name': f'server_sharing_{safe_username}_role',
+        'description': f'Server sharing of {user}',
+        'scopes': [f'access:servers!user={user}'],
+        'groups': [f'server_sharing_{safe_username}']
+    }
+
+    sharing_group_editing_role = {
+        'name': f'server_sharing_{safe_username}_group_editing_role',
+        'description': f'Edit server_sharing_{safe_username} group',
+        'scopes': [f'groups!group=server_sharing_{safe_username}'],
+        'users': [user]
+    }
+
+    usernames_reading_role = {
+        'name': f'usernames_reading_{safe_username}_role',
+        'description': 'Usernames reading group',
+        'scopes': ['list:users'],
+        'users': [user]
+    }
+
+    roles.append(sharing_role)
+    roles.append(sharing_group_editing_role)
+    roles.append(usernames_reading_role)
+
+# Required for getting user reading scope in the JUPYTERHUB_API_TOKEN on user server
+roles.append({
+    'name': 'server',
+    'scopes': ['inherit'],
+})
+
+c.JupyterHub.load_groups = groups
+c.JupyterHub.load_roles = roles
+
+# Set up environment variables
+c.KubeSpawner.environment = {
+    'CONDA_ENVS_PATH': '/opt/modules/conda-envs/',
+    'LMOD_SYSTEM_DEFAULT_MODULES': lambda spawner: str(spawner.user_options.get('modules', 'StdEnv')), #Get the list of modules from user options or fall back to the StdEnv
+    'MODULEPATH': '/opt/modules/modulefiles',
+    'USER_OPTIONS': lambda spawner: str(spawner.user_options),
+}
+
+# Set up WIPP-related environment variables
+if get_config("hub.wipp.enabled"):
+    c.KubeSpawner.environment.update({
+        'WIPP_UI_URL': get_config("hub.wipp.UIValue"),
+        'WIPP_API_INTERNAL_URL': get_config("hub.wipp.apiURL"),
+        'WIPP_NOTEBOOKS_PATH': os.path.join(get_config("hub.wipp.mountPath"), get_config("hub.wipp.tempNotebooksRelPath")),
+        'PLUGIN_TEMP_PATH': os.path.join(get_config("hub.wipp.mountPath"), get_config("hub.wipp.tempPluginsRelPath"))
+    })
+
+# Set up Polus Notebooks Hub environment variables
+if get_config("hub.polusNotebooksHub.enabled"):
+    c.KubeSpawner.environment.update({
+        'POLUS_NOTEBOOKS_HUB_API': 'POLUS_NOTEBOOKS_HUB_API_VALUE',
+        'POLUS_NOTEBOOKS_HUB_FILE_LOGGING_ENABLED': True
+    })
+
+c.JupyterHub.services = [
+    {
+        # Service to shutdown inactive Notebook servers after --timeout seconds
+        'name': 'cull-idle',
+        'admin': True,
+        'command': [sys.executable, '/srv/jupyterhub/config/cull-idle-servers.py', '--timeout=3600'],
+    },
+    {
+        # Service admin token (used in Notebooks Hub and config-wrapper)
+        'name': 'service-token',
+        'admin': True,
+        'api_token': get_secret_value("adminToken"),
+    }
+]

--- a/deploy/helm/files/hub/jupyterhub-config.py
+++ b/deploy/helm/files/hub/jupyterhub-config.py
@@ -125,13 +125,14 @@ c.JupyterHub.hub_ip='0.0.0.0'
 # Required for AWS
 c.JupyterHub.hub_connect_ip='jupyterhub-internal'
 
-# configure the hub db connection
-
-# Configure Postgres database
-# postgres_db = os.getenv('POSTGRES_DB')
-# postgres_user = os.getenv('POSTGRES_USER')
-# postgres_password = os.getenv('POSTGRES_PASSWORD')
-# c.JupyterHub.db_url = 'postgresql://' + postgres_user + ':' + postgres_password + '@' + 'jupyterhub-postgres-service' + '/' + postgres_db
+# configure the JupyterHub database
+if get_config("postgresql.enabled"):
+    postgres_db = get_config("postgresql.postgresqlDatabase")
+    postgres_user = get_config("postgresql.postgresqlUsername")
+    postgres_password = get_config("postgresql.postgresqlPassword")
+    c.JupyterHub.db_url = 'postgresql://' + postgres_user + ':' + postgres_password + '@' + release_name + '-postgresql-headless' + '/' + postgres_db
+else:
+    c.JupyterHub.db_url = "sqlite:///jupyterhub.sqlite"
 
 c.JupyterHub.cleanup_servers=False
 c.JupyterHub.cookie_secret_file = '/srv/jupyterhub/jupyterhub_cookie_secret'

--- a/deploy/helm/files/hub/z2jh.py
+++ b/deploy/helm/files/hub/z2jh.py
@@ -1,0 +1,120 @@
+"""
+Utility methods for use in jupyterhub_config.py and dynamic subconfigs.
+
+Methods here can be imported by extraConfig in values.yaml
+"""
+from collections import Mapping
+from functools import lru_cache
+import os
+
+import yaml
+
+# memoize so we only load config once
+@lru_cache()
+def _load_config():
+    """Load the Helm chart configuration used to render the Helm templates of
+    the chart from a mounted k8s Secret, and merge in values from an optionally
+    mounted secret (hub.existingSecret)."""
+
+    cfg = {}
+    for source in ("secret/values.yaml", "existing-secret/values.yaml"):
+        path = f"/usr/local/etc/jupyterhub/{source}"
+        if os.path.exists(path):
+            print(f"Loading {path}")
+            with open(path) as f:
+                values = yaml.safe_load(f)
+            cfg = _merge_dictionaries(cfg, values)
+        else:
+            print(f"No config at {path}")
+    return cfg
+
+
+@lru_cache()
+def _get_config_value(key):
+    """Load value from the k8s ConfigMap given a key."""
+
+    path = f"/usr/local/etc/jupyterhub/config/{key}"
+    if os.path.exists(path):
+        with open(path) as f:
+            return f.read()
+    else:
+        raise Exception(f"{path} not found!")
+
+
+@lru_cache()
+def get_secret_value(key, default="never-explicitly-set"):
+    """Load value from the user managed k8s Secret or the default k8s Secret
+    given a key."""
+
+    for source in ("admin-token-secret", "existing-secret", "secret"):
+        path = f"/usr/local/etc/jupyterhub/{source}/{key}"
+        if os.path.exists(path):
+            with open(path) as f:
+                return f.read()
+    if default != "never-explicitly-set":
+        return default
+    raise Exception(f"{key} not found in either k8s Secret!")
+
+
+def get_name(name):
+    """Returns the fullname of a resource given its short name"""
+    return _get_config_value(name)
+
+
+def get_name_env(name, suffix=""):
+    """Returns the fullname of a resource given its short name along with a
+    suffix, converted to uppercase with dashes replaced with underscores. This
+    is useful to reference named services associated environment variables, such
+    as PROXY_PUBLIC_SERVICE_PORT."""
+    env_key = _get_config_value(name) + suffix
+    env_key = env_key.upper().replace("-", "_")
+    return os.environ[env_key]
+
+
+def _merge_dictionaries(a, b):
+    """Merge two dictionaries recursively.
+
+    Simplified From https://stackoverflow.com/a/7205107
+    """
+    merged = a.copy()
+    for key in b:
+        if key in a:
+            if isinstance(a[key], Mapping) and isinstance(b[key], Mapping):
+                merged[key] = _merge_dictionaries(a[key], b[key])
+            else:
+                merged[key] = b[key]
+        else:
+            merged[key] = b[key]
+    return merged
+
+
+def get_config(key, default=None):
+    """
+    Find a config item of a given name & return it
+
+    Parses everything as YAML, so lists and dicts are available too
+
+    get_config("a.b.c") returns config['a']['b']['c']
+    """
+    value = _load_config()
+    # resolve path in yaml
+    for level in key.split("."):
+        if not isinstance(value, dict):
+            # a parent is a scalar or null,
+            # can't resolve full path
+            return default
+        if level not in value:
+            return default
+        else:
+            value = value[level]
+    return value
+
+
+def set_config_if_not_none(cparent, name, key):
+    """
+    Find a config item of a given name, set the corresponding Jupyter
+    configuration item if not None
+    """
+    data = get_config(key)
+    if data is not None:
+        setattr(cparent, name, data)

--- a/deploy/helm/templates/_helpers-names.tpl
+++ b/deploy/helm/templates/_helpers-names.tpl
@@ -1,0 +1,256 @@
+{{- /*
+    These helpers encapsulates logic on how we name resources. They also enable
+    parent charts to reference these dynamic resource names.
+
+    To avoid duplicating documentation, for more information, please see the the
+    fullnameOverride entry in schema.yaml or the configuration reference that
+    schema.yaml renders to.
+
+    https://z2jh.jupyter.org/en/latest/resources/reference.html#fullnameOverride
+*/}}
+
+
+
+{{- /*
+    Utility templates
+*/}}
+
+{{- /*
+    Renders to a prefix for the chart's resource names. This prefix is assumed to
+    make the resource name cluster unique.
+*/}}
+{{- define "jupyterhub.fullname" -}}
+    {{- /*
+        We have implemented a trick to allow a parent chart depending on this
+        chart to call these named templates.
+
+        Caveats and notes:
+
+            1. While parent charts can reference these, grandparent charts can't.
+            2. Parent charts must not use an alias for this chart.
+            3. There is no failsafe workaround to above due to
+               https://github.com/helm/helm/issues/9214.
+            4. .Chart is of its own type (*chart.Metadata) and needs to be casted
+               using "toYaml | fromYaml" in order to be able to use normal helm
+               template functions on it.
+    */}}
+    {{- $fullname_override := .Values.fullnameOverride }}
+    {{- $name_override := .Values.nameOverride }}
+    {{- if ne .Chart.Name "jupyterhub" }}
+        {{- if .Values.jupyterhub }}
+            {{- $fullname_override = .Values.jupyterhub.fullnameOverride }}
+            {{- $name_override = .Values.jupyterhub.nameOverride }}
+        {{- end }}
+    {{- end }}
+
+    {{- if eq (typeOf $fullname_override) "string" }}
+        {{- $fullname_override }}
+    {{- else }}
+        {{- $name := $name_override | default .Chart.Name }}
+        {{- if contains $name .Release.Name }}
+            {{- .Release.Name }}
+        {{- else }}
+            {{- .Release.Name }}-{{ $name }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- /*
+    Renders to a blank string or if the fullname template is truthy renders to it
+    with an appended dash.
+*/}}
+{{- define "jupyterhub.fullname.dash" -}}
+    {{- if (include "jupyterhub.fullname" .) }}
+        {{- include "jupyterhub.fullname" . }}-
+    {{- end }}
+{{- end }}
+
+
+
+{{- /*
+    Namespaced resources
+*/}}
+
+{{- /* hub Deployment */}}
+{{- define "jupyterhub.hub.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}hub
+{{- end }}
+
+{{- /* hub-existing-secret Secret */}}
+{{- define "jupyterhub.hub-existing-secret.fullname" -}}
+    {{- /* A hack to avoid issues from invoking this from a parent Helm chart. */}}
+    {{- $existing_secret := .Values.hub.existingSecret }}
+    {{- if ne .Chart.Name "jupyterhub" }}
+        {{- $existing_secret = .Values.jupyterhub.hub.existingSecret }}
+    {{- end }}
+    {{- if $existing_secret }}
+        {{- $existing_secret }}
+    {{- end }}
+{{- end }}
+
+{{- /* hub-existing-secret-or-default Secret */}}
+{{- define "jupyterhub.hub-existing-secret-or-default.fullname" -}}
+    {{- include "jupyterhub.hub-existing-secret.fullname" . | default (include "jupyterhub.hub.fullname" .) }}
+{{- end }}
+
+{{- /* hub PVC */}}
+{{- define "jupyterhub.hub-pvc.fullname" -}}
+    {{- include "jupyterhub.hub.fullname" . }}-db-dir
+{{- end }}
+
+{{- /* proxy Deployment */}}
+{{- define "jupyterhub.proxy.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}proxy
+{{- end }}
+
+{{- /* proxy-api Service */}}
+{{- define "jupyterhub.proxy-api.fullname" -}}
+    {{- include "jupyterhub.proxy.fullname" . }}-api
+{{- end }}
+
+{{- /* proxy-http Service */}}
+{{- define "jupyterhub.proxy-http.fullname" -}}
+    {{- include "jupyterhub.proxy.fullname" . }}-http
+{{- end }}
+
+{{- /* proxy-public Service */}}
+{{- define "jupyterhub.proxy-public.fullname" -}}
+    {{- include "jupyterhub.proxy.fullname" . }}-public
+{{- end }}
+
+{{- /* proxy-public-tls Secret */}}
+{{- define "jupyterhub.proxy-public-tls.fullname" -}}
+    {{- include "jupyterhub.proxy-public.fullname" . }}-tls-acme
+{{- end }}
+
+{{- /* proxy-public-manual-tls Secret */}}
+{{- define "jupyterhub.proxy-public-manual-tls.fullname" -}}
+    {{- include "jupyterhub.proxy-public.fullname" . }}-manual-tls
+{{- end }}
+
+{{- /* autohttps Deployment */}}
+{{- define "jupyterhub.autohttps.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}autohttps
+{{- end }}
+
+{{- /* user-scheduler Deployment */}}
+{{- define "jupyterhub.user-scheduler-deploy.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}user-scheduler
+{{- end }}
+
+{{- /* user-scheduler leader election lock resource */}}
+{{- define "jupyterhub.user-scheduler-lock.fullname" -}}
+    {{- include "jupyterhub.user-scheduler-deploy.fullname" . }}-lock
+{{- end }}
+
+{{- /* user-placeholder StatefulSet */}}
+{{- define "jupyterhub.user-placeholder.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}user-placeholder
+{{- end }}
+
+{{- /* image-awaiter Job */}}
+{{- define "jupyterhub.hook-image-awaiter.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}hook-image-awaiter
+{{- end }}
+
+{{- /* hook-image-puller DaemonSet */}}
+{{- define "jupyterhub.hook-image-puller.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}hook-image-puller
+{{- end }}
+
+{{- /* continuous-image-puller DaemonSet */}}
+{{- define "jupyterhub.continuous-image-puller.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}continuous-image-puller
+{{- end }}
+
+{{- /* singleuser NetworkPolicy */}}
+{{- define "jupyterhub.singleuser.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}singleuser
+{{- end }}
+
+{{- /* image-pull-secret Secret */}}
+{{- define "jupyterhub.image-pull-secret.fullname" -}}
+    {{- include "jupyterhub.fullname.dash" . }}image-pull-secret
+{{- end }}
+
+{{- /* Ingress */}}
+{{- define "jupyterhub.ingress.fullname" -}}
+    {{- if (include "jupyterhub.fullname" .) }}
+        {{- include "jupyterhub.fullname" . }}
+    {{- else -}}
+        jupyterhub
+    {{- end }}
+{{- end }}
+
+
+
+{{- /*
+    Cluster wide resources
+
+    We enforce uniqueness of names for our cluster wide resources. We assume that
+    the prefix from setting fullnameOverride to null or a string will be cluster
+    unique.
+*/}}
+
+{{- /* Priority */}}
+{{- define "jupyterhub.priority.fullname" -}}
+    {{- if (include "jupyterhub.fullname" .) }}
+        {{- include "jupyterhub.fullname" . }}
+    {{- else }}
+        {{- .Release.Name }}-default-priority
+    {{- end }}
+{{- end }}
+
+{{- /* user-placeholder Priority */}}
+{{- define "jupyterhub.user-placeholder-priority.fullname" -}}
+    {{- if (include "jupyterhub.fullname" .) }}
+        {{- include "jupyterhub.user-placeholder.fullname" . }}
+    {{- else }}
+        {{- .Release.Name }}-user-placeholder-priority
+    {{- end }}
+{{- end }}
+
+{{- /* user-scheduler's registered name */}}
+{{- define "jupyterhub.user-scheduler.fullname" -}}
+    {{- if (include "jupyterhub.fullname" .) }}
+        {{- include "jupyterhub.user-scheduler-deploy.fullname" . }}
+    {{- else }}
+        {{- .Release.Name }}-user-scheduler
+    {{- end }}
+{{- end }}
+
+
+
+{{- /*
+    A template to render all the named templates in this file for use in the
+    hub's ConfigMap.
+
+    It is important we keep this in sync with the available templates.
+*/}}
+{{- define "jupyterhub.name-templates" -}}
+fullname: {{ include "jupyterhub.fullname" . | quote }}
+fullname-dash: {{ include "jupyterhub.fullname.dash" . | quote }}
+hub: {{ include "jupyterhub.hub.fullname" . | quote }}
+hub-existing-secret: {{ include "jupyterhub.hub-existing-secret.fullname" . | quote }}
+hub-existing-secret-or-default: {{ include "jupyterhub.hub-existing-secret-or-default.fullname" . | quote }}
+hub-pvc: {{ include "jupyterhub.hub-pvc.fullname" . | quote }}
+proxy: {{ include "jupyterhub.proxy.fullname" . | quote }}
+proxy-api: {{ include "jupyterhub.proxy-api.fullname" . | quote }}
+proxy-http: {{ include "jupyterhub.proxy-http.fullname" . | quote }}
+proxy-public: {{ include "jupyterhub.proxy-public.fullname" . | quote }}
+proxy-public-tls: {{ include "jupyterhub.proxy-public-tls.fullname" . | quote }}
+proxy-public-manual-tls: {{ include "jupyterhub.proxy-public-manual-tls.fullname" . | quote }}
+autohttps: {{ include "jupyterhub.autohttps.fullname" . | quote }}
+user-scheduler-deploy: {{ include "jupyterhub.user-scheduler-deploy.fullname" . | quote }}
+user-scheduler-lock: {{ include "jupyterhub.user-scheduler-lock.fullname" . | quote }}
+user-placeholder: {{ include "jupyterhub.user-placeholder.fullname" . | quote }}
+hook-image-awaiter: {{ include "jupyterhub.hook-image-awaiter.fullname" . | quote }}
+hook-image-puller: {{ include "jupyterhub.hook-image-puller.fullname" . | quote }}
+continuous-image-puller: {{ include "jupyterhub.continuous-image-puller.fullname" . | quote }}
+singleuser: {{ include "jupyterhub.singleuser.fullname" . | quote }}
+image-pull-secret: {{ include "jupyterhub.image-pull-secret.fullname" . | quote }}
+ingress: {{ include "jupyterhub.ingress.fullname" . | quote }}
+priority: {{ include "jupyterhub.priority.fullname" . | quote }}
+user-placeholder-priority: {{ include "jupyterhub.user-placeholder-priority.fullname" . | quote }}
+user-scheduler: {{ include "jupyterhub.user-scheduler.fullname" . | quote }}
+{{- end }}

--- a/deploy/helm/templates/_helpers-names.tpl
+++ b/deploy/helm/templates/_helpers-names.tpl
@@ -93,9 +93,14 @@
     {{- include "jupyterhub.hub-existing-secret.fullname" . | default (include "jupyterhub.hub.fullname" .) }}
 {{- end }}
 
-{{- /* hub PVC */}}
-{{- define "jupyterhub.hub-pvc.fullname" -}}
-    {{- include "jupyterhub.hub.fullname" . }}-db-dir
+{{- /* Shared Notebooks PVC */}}
+{{- define "jupyterhub.hub-shared-notebooks-pvc.fullname" -}}
+    {{- include "jupyterhub.hub.fullname" . }}-{{ .Values.hub.storage.sharedNotebooksClaimName }}
+{{- end }}
+
+{{- /* Modules PVC */}}
+{{- define "jupyterhub.hub-modules-pvc.fullname" -}}
+    {{- include "jupyterhub.hub.fullname" . }}-{{ .Values.hub.storage.modulesClaimName }}
 {{- end }}
 
 {{- /* proxy Deployment */}}
@@ -233,7 +238,8 @@ fullname-dash: {{ include "jupyterhub.fullname.dash" . | quote }}
 hub: {{ include "jupyterhub.hub.fullname" . | quote }}
 hub-existing-secret: {{ include "jupyterhub.hub-existing-secret.fullname" . | quote }}
 hub-existing-secret-or-default: {{ include "jupyterhub.hub-existing-secret-or-default.fullname" . | quote }}
-hub-pvc: {{ include "jupyterhub.hub-pvc.fullname" . | quote }}
+hub-shared-notebooks-pvc: {{ include "jupyterhub.hub-shared-notebooks-pvc.fullname" . | quote }}
+hub-modules-pvc: {{ include "jupyterhub.hub-modules-pvc.fullname" . | quote }}
 proxy: {{ include "jupyterhub.proxy.fullname" . | quote }}
 proxy-api: {{ include "jupyterhub.proxy-api.fullname" . | quote }}
 proxy-http: {{ include "jupyterhub.proxy-http.fullname" . | quote }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,363 @@
+{{- /*
+  ## About
+  This file contains helpers to systematically name, label and select Kubernetes
+  objects we define in the .yaml template files.
+
+
+  ## How helpers work
+  Helm helper functions is a good way to avoid repeating something. They will
+  generate some output based on one single dictionary of input that we call the
+  helpers scope. When you are in helm, you access your current scope with a
+  single a single punctuation (.).
+
+  When you ask a helper to render its content, one often forward the current
+  scope to the helper in order to allow it to access .Release.Name,
+  .Values.rbac.enabled and similar values.
+
+  #### Example - Passing the current scope
+  {{ include "jupyterhub.commonLabels" . }}
+
+  It would be possible to pass something specific instead of the current scope
+  (.), but that would make .Release.Name etc. inaccessible by the helper which
+  is something we aim to avoid.
+
+  #### Example - Passing a new scope
+  {{ include "demo.bananaPancakes" (dict "pancakes" 5 "bananas" 3) }}
+
+  To let a helper access the current scope along with additional values we have
+  opted to create dictionary containing additional values that is then populated
+  with additional values from the current scope through a the merge function.
+
+  #### Example - Passing a new scope augmented with the old
+  {{- $_ := merge (dict "appLabel" "kube-lego") . }}
+  {{- include "jupyterhub.matchLabels" $_ | nindent 6 }}
+
+  In this way, the code within the definition of `jupyterhub.matchLabels` will
+  be able to access .Release.Name and .appLabel.
+
+  NOTE:
+    The ordering of merge is crucial, the latter argument is merged into the
+    former. So if you would swap the order you would influence the current scope
+    risking unintentional behavior. Therefore, always put the fresh unreferenced
+    dictionary (dict "key1" "value1") first and the current scope (.) last.
+
+
+  ## Declared helpers
+  - appLabel          |
+  - componentLabel    |
+  - commonLabels      | uses appLabel
+  - labels            | uses commonLabels
+  - matchLabels       | uses labels
+  - podCullerSelector | uses matchLabels
+
+
+  ## Example usage
+  ```yaml
+  # Excerpt from proxy/autohttps/deployment.yaml
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: {{ include "jupyterhub.autohttps.fullname" . }}
+    labels:
+      {{- include "jupyterhub.labels" . | nindent 4 }}
+  spec:
+    selector:
+      matchLabels:
+        {{- include "jupyterhub.matchLabels" $_ | nindent 6 }}
+    template:
+      metadata:
+        labels:
+          {{- include "jupyterhub.labels" $_ | nindent 8 }}
+          hub.jupyter.org/network-access-proxy-http: "true"
+  ```
+
+  NOTE:
+    The "jupyterhub.matchLabels" and "jupyterhub.labels" is passed an augmented
+    scope that will influence the helpers' behavior. It get the current scope
+    "." but merged with a dictionary containing extra key/value pairs. In this
+    case the "." scope was merged with a small dictionary containing only one
+    key/value pair "appLabel: kube-lego". It is required for kube-lego to
+    function properly. It is a way to override the default app label's value.
+*/}}
+
+
+{{- /*
+  jupyterhub.appLabel:
+    Used by "jupyterhub.labels".
+*/}}
+{{- define "jupyterhub.appLabel" -}}
+{{ .Values.nameOverride | default .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{- /*
+  jupyterhub.componentLabel:
+    Used by "jupyterhub.labels".
+
+    NOTE: The component label is determined by either...
+    - 1: The provided scope's .componentLabel
+    - 2: The template's filename if living in the root folder
+    - 3: The template parent folder's name
+    -  : ...and is combined with .componentPrefix and .componentSuffix
+*/}}
+{{- define "jupyterhub.componentLabel" -}}
+{{- $file := .Template.Name | base | trimSuffix ".yaml" -}}
+{{- $parent := .Template.Name | dir | base | trimPrefix "templates" -}}
+{{- $component := .componentLabel | default $parent | default $file -}}
+{{- $component := print (.componentPrefix | default "") $component (.componentSuffix | default "") -}}
+{{ $component }}
+{{- end }}
+
+
+{{- /*
+  jupyterhub.commonLabels:
+    Foundation for "jupyterhub.labels".
+    Provides labels: app, release, (chart and heritage).
+*/}}
+{{- define "jupyterhub.commonLabels" -}}
+app: {{ .appLabel | default (include "jupyterhub.appLabel" .) }}
+release: {{ .Release.Name }}
+{{- if not .matchLabels }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+heritage: {{ .heritageLabel | default .Release.Service }}
+{{- end }}
+{{- end }}
+
+
+{{- /*
+  jupyterhub.labels:
+    Provides labels: component, app, release, (chart and heritage).
+*/}}
+{{- define "jupyterhub.labels" -}}
+component: {{ include "jupyterhub.componentLabel" . }}
+{{ include "jupyterhub.commonLabels" . }}
+{{- end }}
+
+
+{{- /*
+  jupyterhub.matchLabels:
+    Used to provide pod selection labels: component, app, release.
+*/}}
+{{- define "jupyterhub.matchLabels" -}}
+{{- $_ := merge (dict "matchLabels" true) . -}}
+{{ include "jupyterhub.labels" $_ }}
+{{- end }}
+
+
+{{- /*
+  jupyterhub.dockerconfigjson:
+    Creates a base64 encoded docker registry json blob for use in a image pull
+    secret, just like the `kubectl create secret docker-registry` command does
+    for the generated secrets data.dockerconfigjson field. The output is
+    verified to be exactly the same even if you have a password spanning
+    multiple lines as you may need to use a private GCR registry.
+
+    - https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+*/}}
+{{- define "jupyterhub.dockerconfigjson" -}}
+{{ include "jupyterhub.dockerconfigjson.yaml" . | b64enc }}
+{{- end }}
+
+{{- define "jupyterhub.dockerconfigjson.yaml" -}}
+{{- with .Values.imagePullSecret -}}
+{
+  "auths": {
+    {{ .registry | default "https://index.docker.io/v1/" | quote }}: {
+      "username": {{ .username | quote }},
+      "password": {{ .password | quote }},
+      {{- if .email }}
+      "email": {{ .email | quote }},
+      {{- end }}
+      "auth": {{ (print .username ":" .password) | b64enc | quote }}
+    }
+  }
+}
+{{- end }}
+{{- end }}
+
+{{- /*
+  jupyterhub.imagePullSecrets
+    Augments passed .pullSecrets with $.Values.imagePullSecrets
+*/}}
+{{- define "jupyterhub.imagePullSecrets" -}}
+{{- /* Populate $_.list with all relevant entries */}}
+{{- $_ := dict "list" (concat .image.pullSecrets .root.Values.imagePullSecrets | uniq) }}
+{{- if and .root.Values.imagePullSecret.create .root.Values.imagePullSecret.automaticReferenceInjection }}
+{{- $__ := set $_ "list" (append $_.list (include "jupyterhub.image-pull-secret.fullname" .root) | uniq) }}
+{{- end }}
+
+{{- /* Decide if something should be written */}}
+{{- if not (eq ($_.list | toJson) "[]") }}
+
+{{- /* Process the $_.list where strings become dicts with a name key and the
+strings become the name keys' values into $_.res */}}
+{{- $_ := set $_ "res" list }}
+{{- range $_.list }}
+{{- if eq (typeOf .) "string" }}
+{{- $__ := set $_ "res" (append $_.res (dict "name" .)) }}
+{{- else }}
+{{- $__ := set $_ "res" (append $_.res .) }}
+{{- end }}
+{{- end }}
+
+{{- /* Write the results */}}
+{{- $_.res | toJson }}
+
+{{- end }}
+{{- end }}
+
+{{- /*
+  jupyterhub.singleuser.resources:
+    The resource request of a singleuser.
+*/}}
+{{- define "jupyterhub.singleuser.resources" -}}
+{{- $r1 := .Values.singleuser.cpu.guarantee -}}
+{{- $r2 := .Values.singleuser.memory.guarantee -}}
+{{- $r3 := .Values.singleuser.extraResource.guarantees -}}
+{{- $r := or $r1 $r2 $r3 -}}
+{{- $l1 := .Values.singleuser.cpu.limit -}}
+{{- $l2 := .Values.singleuser.memory.limit -}}
+{{- $l3 := .Values.singleuser.extraResource.limits -}}
+{{- $l := or $l1 $l2 $l3 -}}
+{{- if $r -}}
+requests:
+  {{- if $r1 }}
+  cpu: {{ .Values.singleuser.cpu.guarantee }}
+  {{- end }}
+  {{- if $r2 }}
+  memory: {{ .Values.singleuser.memory.guarantee }}
+  {{- end }}
+  {{- if $r3 }}
+  {{- range $key, $value := .Values.singleuser.extraResource.guarantees }}
+  {{ $key | quote }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if $l }}
+limits:
+  {{- if $l1 }}
+  cpu: {{ .Values.singleuser.cpu.limit }}
+  {{- end }}
+  {{- if $l2 }}
+  memory: {{ .Values.singleuser.memory.limit }}
+  {{- end }}
+  {{- if $l3 }}
+  {{- range $key, $value := .Values.singleuser.extraResource.limits }}
+  {{ $key | quote }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- /*
+  jupyterhub.extraEnv:
+    Output YAML formatted EnvVar entries for use in a containers env field.
+*/}}
+{{- define "jupyterhub.extraEnv" -}}
+{{- include "jupyterhub.extraEnv.withTrailingNewLine" . | trimSuffix "\n" }}
+{{- end }}
+
+{{- define "jupyterhub.extraEnv.withTrailingNewLine" -}}
+{{- if . }}
+{{- /* If extraEnv is a list, we inject it as it is. */}}
+{{- if eq (typeOf .) "[]interface {}" }}
+{{- . | toYaml }}
+
+{{- /* If extraEnv is a map, we differentiate two cases: */}}
+{{- else if eq (typeOf .) "map[string]interface {}" }}
+{{- range $key, $value := . }}
+{{- /*
+    - If extraEnv.someKey has a map value, then we add the value as a YAML
+      parsed list element and use the key as the name value unless its
+      explicitly set.
+*/}}
+{{- if eq (typeOf $value) "map[string]interface {}" }}
+{{- merge (dict) $value (dict "name" $key) | list | toYaml | println }}
+{{- /*
+    - If extraEnv.someKey has a string value, then we use the key as the
+      environment variable name for the value.
+*/}}
+{{- else if eq (typeOf $value) "string" -}}
+- name: {{ $key | quote }}
+  value: {{ $value | quote | println }}
+{{- else }}
+{{- printf "?.extraEnv.%s had an unexpected type (%s)" $key (typeOf $value) | fail }}
+{{- end }}
+{{- end }} {{- /* end of range */}}
+{{- end }}
+{{- end }} {{- /* end of: if . */}}
+{{- end }} {{- /* end of definition */}}
+
+{{- /*
+  jupyterhub.extraFiles.data:
+    Renders content for a k8s Secret's data field, coming from extraFiles with
+    binaryData entries.
+*/}}
+{{- define "jupyterhub.extraFiles.data.withNewLineSuffix" -}}
+    {{- range $file_key, $file_details := . }}
+        {{- include "jupyterhub.extraFiles.validate-file" (list $file_key $file_details) }}
+        {{- if $file_details.binaryData }}
+            {{- $file_key | quote }}: {{ $file_details.binaryData | nospace | quote }}{{ println }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- define "jupyterhub.extraFiles.data" -}}
+    {{- include "jupyterhub.extraFiles.data.withNewLineSuffix" . | trimSuffix "\n" }}
+{{- end }}
+
+{{- /*
+  jupyterhub.extraFiles.stringData:
+    Renders content for a k8s Secret's stringData field, coming from extraFiles
+    with either data or stringData entries.
+*/}}
+{{- define "jupyterhub.extraFiles.stringData.withNewLineSuffix" -}}
+    {{- range $file_key, $file_details := . }}
+        {{- include "jupyterhub.extraFiles.validate-file" (list $file_key $file_details) }}
+        {{- $file_name := $file_details.mountPath | base }}
+        {{- if $file_details.stringData }}
+            {{- $file_key | quote }}: |
+              {{- $file_details.stringData | trimSuffix "\n" | nindent 2 }}{{ println }}
+        {{- end }}
+        {{- if $file_details.data }}
+            {{- $file_key | quote }}: |
+              {{- if or (eq (ext $file_name) ".yaml") (eq (ext $file_name) ".yml") }}
+              {{- $file_details.data | toYaml | nindent 2 }}{{ println }}
+              {{- else if eq (ext $file_name) ".json" }}
+              {{- $file_details.data | toJson | nindent 2 }}{{ println }}
+              {{- else if eq (ext $file_name) ".toml" }}
+              {{- $file_details.data | toToml | trimSuffix "\n" | nindent 2 }}{{ println }}
+              {{- else }}
+              {{- print "\n\nextraFiles entries with 'data' (" $file_key " > " $file_details.mountPath ") needs to have a filename extension of .yaml, .yml, .json, or .toml!" | fail }}
+              {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- define "jupyterhub.extraFiles.stringData" -}}
+    {{- include "jupyterhub.extraFiles.stringData.withNewLineSuffix" . | trimSuffix "\n" }}
+{{- end }}
+
+{{- define "jupyterhub.extraFiles.validate-file" -}}
+    {{- $file_key := index . 0 }}
+    {{- $file_details := index . 1 }}
+
+    {{- /* Use of mountPath. */}}
+    {{- if not ($file_details.mountPath) }}
+        {{- print "\n\nextraFiles entries (" $file_key ") must contain the field 'mountPath'." | fail }}
+    {{- end }}
+
+    {{- /* Use one of stringData, binaryData, data. */}}
+    {{- $field_count := 0 }}
+    {{- if $file_details.data }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if $file_details.stringData }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if $file_details.binaryData }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if ne $field_count 1 }}
+        {{- print "\n\nextraFiles entries (" $file_key ") must only contain one of the fields: 'data', 'stringData', and 'binaryData'." | fail }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/templates/hub/configmap.yaml
+++ b/deploy/helm/templates/hub/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jupyterhub.hub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+data:
+  {{- /*
+    Glob files to allow them to be mounted by the hub pod
+
+    jupyterhub_config: |
+      multi line string content...
+    z2jh.py: |
+      multi line string content...
+  */}}
+  {{- (.Files.Glob "files/hub/*").AsConfig | nindent 2 }}

--- a/deploy/helm/templates/hub/deployment.yaml
+++ b/deploy/helm/templates/hub/deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jupyterhub.hub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "jupyterhub.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+      annotations:
+        {{- /* This lets us autorestart when the secret changes! */}}
+        checksum/config-map: {{ include (print .Template.BasePath "/hub/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print .Template.BasePath "/hub/secret.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: jupyterhub-sa
+      containers:
+        - name: jupyterhub
+          image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+              # This name will be used in the Service.
+              name: jupyter-http
+            - containerPort: 8081
+              # This name will be used in the Service.
+              name: jupyter-in
+          env:
+            # - name: OAUTH_CLIENT_ID
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-auth-config
+            #       key: client_id
+            # - name: OAUTH_CLIENT_SECRET
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-auth-config
+            #       key: client_secret
+            # - name: TENANT
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-auth-config
+            #       key: tenant
+            # - name: AUTH_URL
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-auth-config
+            #       key: auth_url
+            # - name: OAUTH_CALLBACK_URL
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-auth-config
+            #       key: oauth_callback_url
+            # - name: ADMIN_USERS
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-auth-config
+            #       key: admin_users
+            - name: ADMIN_SERVICE_ACC
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jupyterhub.hub.fullname" . }}-admin-token
+                  key: adminToken
+            # - name: POSTGRES_DB
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-postgres-config
+            #       key: db
+            # - name: POSTGRES_USER
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-postgres-config
+            #       key: user
+            # - name: POSTGRES_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: jupyterhub-postgres-config
+            #       key: password
+            # - name: OAUTH2_AUTHORIZE_URL
+            #   value: "$(AUTH_URL)/auth/$(TENANT)/authorize"
+            # - name: OAUTH2_TOKEN_URL
+            #   value: "$(AUTH_URL)/auth/$(TENANT)/oidc/token"
+            # - name: OAUTH2_USERDATA_URL
+            #   value: "$(AUTH_URL)/auth/me"
+          volumeMounts:
+            - mountPath: /srv/jupyterhub/config/jupyterhub-config.py
+              subPath: jupyterhub-config.py
+              name: config
+            - mountPath: /srv/jupyterhub/config/z2jh.py
+              subPath: z2jh.py
+              name: config
+            - mountPath: /usr/local/etc/jupyterhub/config/
+              name: config
+            - mountPath: /usr/local/etc/jupyterhub/secret/
+              name: secret
+            - mountPath: /usr/local/etc/jupyterhub/admin-token-secret/
+              name: admin-token-secret
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "jupyterhub.hub.fullname" . }}
+        - name: secret
+          secret:
+            secretName: {{ include "jupyterhub.hub.fullname" . }}
+        - name: admin-token-secret
+          secret:
+            secretName: {{ include "jupyterhub.hub.fullname" . }}-admin-token

--- a/deploy/helm/templates/hub/deployment.yaml
+++ b/deploy/helm/templates/hub/deployment.yaml
@@ -32,62 +32,31 @@ spec:
               # This name will be used in the Service.
               name: jupyter-in
           env:
-            # - name: OAUTH_CLIENT_ID
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-auth-config
-            #       key: client_id
-            # - name: OAUTH_CLIENT_SECRET
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-auth-config
-            #       key: client_secret
-            # - name: TENANT
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-auth-config
-            #       key: tenant
-            # - name: AUTH_URL
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-auth-config
-            #       key: auth_url
-            # - name: OAUTH_CALLBACK_URL
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-auth-config
-            #       key: oauth_callback_url
-            # - name: ADMIN_USERS
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-auth-config
-            #       key: admin_users
+{{- if .Values.hub.auth.enabled }}
+            - name: OAUTH_CLIENT_ID
+              value: {{ .Values.hub.auth.clientID }}
+            - name: OAUTH_CLIENT_SECRET
+              value: {{ .Values.hub.auth.clientSecret }}
+            - name: TENANT
+              value: {{ .Values.hub.auth.tenant }}
+            - name: AUTH_URL
+              value: {{ .Values.hub.auth.url }}
+            - name: OAUTH_CALLBACK_URL
+              value: {{ .Values.hub.auth.callbackURL }}
+            - name: ADMIN_USERS
+              value: {{ .Values.hub.auth.adminUsers }}
+            - name: OAUTH2_AUTHORIZE_URL
+              value: "$(AUTH_URL)/auth/$(TENANT)/authorize"
+            - name: OAUTH2_TOKEN_URL
+              value: "$(AUTH_URL)/auth/$(TENANT)/oidc/token"
+            - name: OAUTH2_USERDATA_URL
+              value: "$(AUTH_URL)/auth/me"
+{{- end }}
             - name: ADMIN_SERVICE_ACC
               valueFrom:
                 secretKeyRef:
                   name: {{ include "jupyterhub.hub.fullname" . }}-admin-token
                   key: adminToken
-            # - name: POSTGRES_DB
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-postgres-config
-            #       key: db
-            # - name: POSTGRES_USER
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-postgres-config
-            #       key: user
-            # - name: POSTGRES_PASSWORD
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: jupyterhub-postgres-config
-            #       key: password
-            # - name: OAUTH2_AUTHORIZE_URL
-            #   value: "$(AUTH_URL)/auth/$(TENANT)/authorize"
-            # - name: OAUTH2_TOKEN_URL
-            #   value: "$(AUTH_URL)/auth/$(TENANT)/oidc/token"
-            # - name: OAUTH2_USERDATA_URL
-            #   value: "$(AUTH_URL)/auth/me"
           volumeMounts:
             - mountPath: /srv/jupyterhub/config/jupyterhub-config.py
               subPath: jupyterhub-config.py

--- a/deploy/helm/templates/hub/ingress.yaml
+++ b/deploy/helm/templates/hub/ingress.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.hub.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  name: {{ include "jupyterhub.ingress.fullname" . }}
+spec:
+  rules:
+    - host: {{ .Values.hub.ingress.hostName }}
+      http:
+        paths:
+          - backend:
+              serviceName: jupyterhub
+              servicePort: 80
+            path: /
+{{- end }}

--- a/deploy/helm/templates/hub/rbac.yaml
+++ b/deploy/helm/templates/hub/rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jupyterhub-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jupyterhub-role
+rules:
+  - apiGroups: [""]
+    resources: ["*"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jupyterhub-rb
+subjects:
+  - kind: ServiceAccount
+    name: jupyterhub-sa
+roleRef:
+  kind: Role
+  name: jupyterhub-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/templates/hub/rbac.yaml
+++ b/deploy/helm/templates/hub/rbac.yaml
@@ -23,3 +23,39 @@ roleRef:
   kind: Role
   name: jupyterhub-role
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jupyteruser-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: jupyteruser-role
+rules:
+  - apiGroups:
+    - argoproj.io
+    resources:
+    - workflows
+    verbs:
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - create
+    - update
+    - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jupyteruser-rb
+subjects:
+- kind: ServiceAccount
+  name:  jupyteruser-sa
+roleRef:
+  kind: Role
+  name: jupyteruser-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/templates/hub/secret.yaml
+++ b/deploy/helm/templates/hub/secret.yaml
@@ -1,0 +1,23 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "jupyterhub.hub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+type: Opaque
+data:
+    {{- $values := merge dict .Values }}
+    {{- /* also passthrough subset of Chart / Release */}}
+    {{- $_ := set $values "Chart" (dict "Name" .Chart.Name "Version" .Chart.Version) }}
+    {{- $_ := set $values "Release" (pick .Release "Name" "Namespace" "Service") }}
+    values.yaml: {{ $values | toYaml | b64enc | quote }}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "jupyterhub.hub.fullname" . }}-admin-token
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+type: Opaque
+data:
+  adminToken: {{ randAlphaNum 32 | b64enc | quote }}

--- a/deploy/helm/templates/hub/service.yaml
+++ b/deploy/helm/templates/hub/service.yaml
@@ -11,3 +11,17 @@ spec:
     targetPort: jupyter-in
   selector:
     {{- include "jupyterhub.matchLabels" . | nindent 4 }}
+---
+# External JupyterHub UI Service definition
+apiVersion: v1
+kind: Service
+metadata:
+  name: jupyterhub
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    name: http
+    targetPort: jupyter-http
+  selector:
+    {{- include "jupyterhub.matchLabels" . | nindent 4 }}

--- a/deploy/helm/templates/hub/service.yaml
+++ b/deploy/helm/templates/hub/service.yaml
@@ -1,0 +1,13 @@
+# Internal JupyterHub API Service definition
+apiVersion: v1
+kind: Service
+metadata:
+  name: jupyterhub-internal
+spec:
+  ports:
+  - port: 8081
+    name: http
+    # Use named container port.
+    targetPort: jupyter-in
+  selector:
+    {{- include "jupyterhub.matchLabels" . | nindent 4 }}

--- a/deploy/helm/templates/hub/service.yaml
+++ b/deploy/helm/templates/hub/service.yaml
@@ -9,7 +9,7 @@ spec:
       name: http
       # Use named container port.
       targetPort: jupyter-in
-  selector: { { - include "jupyterhub.matchLabels" . | nindent 4 } }
+  selector: {{- include "jupyterhub.matchLabels" . | nindent 4}}
 ---
 # External JupyterHub UI Service definition
 apiVersion: v1
@@ -17,9 +17,9 @@ kind: Service
 metadata:
   name: jupyterhub
 spec:
-  type: { { .Values.hub.service.type } }
+  type: {{.Values.hub.service.type}}
   ports:
     - port: 80
       name: http
       targetPort: jupyter-http
-  selector: { { - include "jupyterhub.matchLabels" . | nindent 4 } }
+  selector: {{- include "jupyterhub.matchLabels" . | nindent 4}}

--- a/deploy/helm/templates/hub/service.yaml
+++ b/deploy/helm/templates/hub/service.yaml
@@ -5,12 +5,11 @@ metadata:
   name: jupyterhub-internal
 spec:
   ports:
-  - port: 8081
-    name: http
-    # Use named container port.
-    targetPort: jupyter-in
-  selector:
-    {{- include "jupyterhub.matchLabels" . | nindent 4 }}
+    - port: 8081
+      name: http
+      # Use named container port.
+      targetPort: jupyter-in
+  selector: { { - include "jupyterhub.matchLabels" . | nindent 4 } }
 ---
 # External JupyterHub UI Service definition
 apiVersion: v1
@@ -18,10 +17,9 @@ kind: Service
 metadata:
   name: jupyterhub
 spec:
-  type: LoadBalancer
+  type: { { .Values.hub.service.type } }
   ports:
-  - port: 80
-    name: http
-    targetPort: jupyter-http
-  selector:
-    {{- include "jupyterhub.matchLabels" . | nindent 4 }}
+    - port: 80
+      name: http
+      targetPort: jupyter-http
+  selector: { { - include "jupyterhub.matchLabels" . | nindent 4 } }

--- a/deploy/helm/templates/hub/storage.yaml
+++ b/deploy/helm/templates/hub/storage.yaml
@@ -4,14 +4,14 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "jupyterhub.hub-shared-notebooks-pvc.fullname" . }}
+  name: {{include "jupyterhub.hub-shared-notebooks-pvc.fullname" .}}
 spec:
-  storageClassName: {{ .Values.global.storageClass }}
+  storageClassName: {{.Values.global.storageClass}}
   accessModes:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.hub.storage.sharedNotebooksStorage }}
+      storage: {{.Values.hub.storage.sharedNotebooksStorage}}
 ---
 #################################################################################################################
 # Create PVC for shared modules storage
@@ -19,11 +19,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "jupyterhub.hub-modules-pvc.fullname" . }}
+  name: {{include "jupyterhub.hub-modules-pvc.fullname" .}}
 spec:
-  storageClassName: {{ .Values.global.storageClass }}
+  storageClassName: {{.Values.global.storageClass}}
   accessModes:
     - ReadWriteMany
   resources:
     requests:
-      storage: { { .Values.hub.storage.modulesStorage } }
+      storage: {{.Values.hub.storage.modulesStorage}}

--- a/deploy/helm/templates/hub/storage.yaml
+++ b/deploy/helm/templates/hub/storage.yaml
@@ -6,9 +6,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ include "jupyterhub.hub-shared-notebooks-pvc.fullname" . }}
 spec:
-  storageClassName: {{ .Values.hub.storage.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
   accessModes:
-  - ReadWriteMany
+    - ReadWriteMany
   resources:
     requests:
       storage: {{ .Values.hub.storage.sharedNotebooksStorage }}
@@ -21,9 +21,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ include "jupyterhub.hub-modules-pvc.fullname" . }}
 spec:
-  storageClassName: {{ .Values.hub.storage.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
   accessModes:
-  - ReadWriteMany
+    - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.hub.storage.modulesStorage }}
+      storage: { { .Values.hub.storage.modulesStorage } }

--- a/deploy/helm/templates/hub/storage.yaml
+++ b/deploy/helm/templates/hub/storage.yaml
@@ -1,0 +1,29 @@
+#################################################################################################################
+# Create PVC for shared notebook storage
+#################################################################################################################
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "jupyterhub.hub-shared-notebooks-pvc.fullname" . }}
+spec:
+  storageClassName: {{ .Values.hub.storage.storageClass }}
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.hub.storage.sharedNotebooksStorage }}
+---
+#################################################################################################################
+# Create PVC for shared modules storage
+#################################################################################################################
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "jupyterhub.hub-modules-pvc.fullname" . }}
+spec:
+  storageClassName: {{ .Values.hub.storage.storageClass }}
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.hub.storage.modulesStorage }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -26,28 +26,42 @@ hub:
   # TODO: Enable configuration for alternative Ingress solutions  
   ingress:
     # Using Ingress is optional and requires preconfiguration within the cluster
-    enabled: true
+    enabled: false
     # Host name for external access
     hostName: null
+  
+  # LabShare Auth configurations
+  auth:
+    enabled: false
+    # Auth service url
+    url: null
+    # Unique tenant configured in LS-Auth
+    tenant: null
+    # Unique client ID configured in the above tenant
+    clientID: null
+    clientSecret: null
+    callbackURL: null
+    adminUsers: null
+    
 
   wipp:
     enabled: false
     storageClaimName: wipp-pv-claim
     mountPath: /opt/shared/wipp
     apiURL: http://wipp-backend:8080/api
-    UIValue: https://wipp-ui.ci.aws.labshare.org
+    UIValue: null
     tempNotebooksRelPath: temp/notebooks
     tempPluginsRelPath: temp/plugins
   
   polusNotebooksHub:
     enabled: false
-    apiURL: https://polus-notebooks-hub-backend.ci.aws.labshare.org
+    apiURL: null
 
 # Configurations for PostgreSQL dependency
 postgresql:
   enabled: true
-  postgresqlDatabase: postgresd
-  postgresqlUsername: blablabla
-  postgresqlPassword: hahahaha
+  postgresqlDatabase: postgresdb
+  postgresqlUsername: postgres
+  postgresqlPassword: postgres
   persistence:
     size: 1Gi

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,4 +1,4 @@
-# Global configurations for PostgreSQL dependency
+# Global chart configuration
 global:
   # Preconfigured Kubernetes Storage Class
   storageClass: aws-efs
@@ -11,7 +11,6 @@ hub:
   notebookVersion: 0.9.0
 
   storage:
-    storageClass: aws-efs
     storagePerUser: 1Gi
     sharedNotebooksStorage: 5Gi
     modulesStorage: 100Gi

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -4,10 +4,14 @@ hub:
     tag: "0.8.1.18"
 
   notebookVersion: 0.9.0
-  storageClass: aws-efs
-  storagePerUser: 1Gi
-  sharedNotebookStoragePVC: notebooks-pv-claim
-  modulesStoragePVC: modules-pv-claim
+
+  storage:
+    storageClass: aws-efs
+    storagePerUser: 1Gi
+    sharedNotebooksStorage: 5Gi
+    modulesStorage: 100Gi
+    sharedNotebooksClaimName: shared-notebooks-pv-claim
+    modulesClaimName: modules-pv-claim
   
   db:
     type: postgres
@@ -15,8 +19,8 @@ hub:
     password:
 
   wipp:
-    enabled: true
-    storagePVC: wipp-pv-claim
+    enabled: false
+    storageClaimName: wipp-pv-claim
     mountPath: /opt/shared/wipp
     apiURL: http://wipp-backend:8080/api
     UIValue: https://wipp-ui.ci.aws.labshare.org
@@ -24,5 +28,5 @@ hub:
     tempPluginsRelPath: temp/plugins
   
   polusNotebooksHub:
-    enabled: true
+    enabled: false
     apiURL: https://polus-notebooks-hub-backend.ci.aws.labshare.org

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,28 @@
+hub:
+  image:
+    name: labshare/jupyterhub
+    tag: "0.8.1.18"
+
+  notebookVersion: 0.9.0
+  storageClass: aws-efs
+  storagePerUser: 1Gi
+  sharedNotebookStoragePVC: notebooks-pv-claim
+  modulesStoragePVC: modules-pv-claim
+  
+  db:
+    type: postgres
+    user:
+    password:
+
+  wipp:
+    enabled: true
+    storagePVC: wipp-pv-claim
+    mountPath: /opt/shared/wipp
+    apiURL: http://wipp-backend:8080/api
+    UIValue: https://wipp-ui.ci.aws.labshare.org
+    tempNotebooksRelPath: temp/notebooks
+    tempPluginsRelPath: temp/plugins
+  
+  polusNotebooksHub:
+    enabled: true
+    apiURL: https://polus-notebooks-hub-backend.ci.aws.labshare.org

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,3 +1,8 @@
+# Global configurations for PostgreSQL dependency
+global:
+  # Preconfigured Kubernetes Storage Class
+  storageClass: aws-efs
+
 hub:
   image:
     name: labshare/jupyterhub
@@ -12,11 +17,6 @@ hub:
     modulesStorage: 100Gi
     sharedNotebooksClaimName: shared-notebooks-pv-claim
     modulesClaimName: modules-pv-claim
-  
-  db:
-    type: postgres
-    user:
-    password:
 
   wipp:
     enabled: false
@@ -30,3 +30,12 @@ hub:
   polusNotebooksHub:
     enabled: false
     apiURL: https://polus-notebooks-hub-backend.ci.aws.labshare.org
+
+# Configurations for PostgreSQL dependency
+postgresql:
+  enabled: true
+  postgresqlDatabase: postgresd
+  postgresqlUsername: blablabla
+  postgresqlPassword: hahahaha
+  persistence:
+    size: 1Gi

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -17,6 +17,19 @@ hub:
     modulesStorage: 100Gi
     sharedNotebooksClaimName: shared-notebooks-pv-claim
     modulesClaimName: modules-pv-claim
+  
+  # JupyterHub external Service configuration
+  service:
+    # Kubernetes Service type (NodePort, ClusterIP, LoadBalancer, ExternalName)
+    type: LoadBalancer
+
+  # JupyterHub Ingress configuration for external access, uses Nginx Ingress by default
+  # TODO: Enable configuration for alternative Ingress solutions  
+  ingress:
+    # Using Ingress is optional and requires preconfiguration within the cluster
+    enabled: true
+    # Host name for external access
+    hostName: null
 
   wipp:
     enabled: false


### PR DESCRIPTION
This PR adds a Helm chart which deploys the whole stack related to LabShare Notebooks application: persistent storage, database, deployments, pods, configmaps and secrets. Chart is based on and should replace raw yaml definitions in `deploy/kubernetes` in the future as we transition to Helm. Note: many of the JupyterHub-config-specific code is reused from https://github.com/jupyterhub/zero-to-jupyterhub-k8s/

Features:
- Deploy LabShare Notebooks
- jupyterhub_config is stored as a simple Python file
- Configurable options for deployment and testing
  - Whether to enable WIPP integration
  - Whether to enable Notebooks Hub integration
  - Whether to use PostgreSQL database deployed alongside or to use local SQLite database in ephemeral JupyterHub storage
  - Whether to use OAuth + LS Auth or dummy authentication
  - Type of k8s service for JupyterHub
  - k8s storageclass
  - Versions of JupyterLab/JupyterHub images
  - PVC size and names
- k8s resource names are prefixed with deployment and chart name, i.e.
  ```
  NAME                                                                   READY   STATUS    RESTARTS   AGE
  test-ci-polus-jupyterhub-hub-868cc45566-crg6r                          1/1     Running   0          28m
  test-ci-polus-jupyterhub-lab-konstantin-2etaletskiy-40labshare-2eorg   1/1     Running   0          37m
  test-ci-postgresql-0                                                   1/1     Running   0          24h
  ```