### PR TITLE
Bugfix: prebuild easybuild-easyconfigs wheel

### DIFF
--- a/deploy/docker/env-installer/Dockerfile
+++ b/deploy/docker/env-installer/Dockerfile
@@ -1,4 +1,7 @@
-FROM labshare/polyglot-notebook:NOTEBOOK_VERSION_LATEST_VALUE
+FROM python:3.9
+RUN pip wheel easybuild-easyconfigs==4.5.3
+
+FROM labshare/polyglot-notebook:0.9.3
 
 USER root
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/bin/jq
@@ -6,7 +9,9 @@ RUN chmod +x /usr/bin/jq
 
 USER $NB_UID
 
+COPY --from=0 /easybuild* .
+
 # Install easybuild
 ENV EASYBUILD_PREFIX=/opt/modules \
     EASYBUILD_BUILDPATH=/tmp/easybuild
-RUN pip install --ignore-installed easybuild==4.5.1
+RUN pip install easybuild_easyconfigs-4.5.3-py3-none-any.whl easybuild==4.5.3


### PR DESCRIPTION
- Use Docker multistage build to pre-build `easybuild-easyconfigs` Python wheel
Workaround for https://github.com/easybuilders/easybuild/issues/790

- Bump easybuild to 4.5.3